### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, master, "dev-*" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Goopil/laravel-redis-sentinel/security/code-scanning/2](https://github.com/Goopil/laravel-redis-sentinel/security/code-scanning/2)

In general, to fix this issue you should define a `permissions` block either at the top (workflow level) or per job, setting the minimum rights required. For this workflow, both jobs only need to read repository contents and use caches; they do not need to write to the repo or manage issues, PRs, etc. The safest and simplest fix is to add a workflow-level `permissions` block with `contents: read`, which will apply to all jobs unless overridden.

Concretely, in `.github/workflows/tests.yml`, add a `permissions:` section near the top of the file, after `name: Tests` and before the `on:` block. Set `contents: read` to minimally satisfy CodeQL’s recommendation and GitHub best practices, and rely on default cache behavior (no extra scopes are required for `actions/cache`). No other functional changes are needed, and no additional imports or methods are required since this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
