### PR TITLE
Feat/laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,15 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [10, 11, 12]
+        laravel: [10, 11, 12, 13]
         redis: [6, 7]
         exclude:
           - php: 8.5
             laravel: 10
           - php: 8.5
             laravel: 11
+          - php: 8.2
+            laravel: 13
 
     name: PHP ${{ matrix.php }} - L${{ matrix.laravel }} - R${{ matrix.redis }}
 
@@ -130,7 +132,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.laravel == 10 && '^8.0' || (matrix.laravel == 11 && '^9.0' || '^10.0') }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}.*" "orchestra/testbench:${{ matrix.laravel == 10 && '^8.0' || (matrix.laravel == 11 && '^9.0' || (matrix.laravel == 12 && '^10.0' || '^11.0')) }}" --no-interaction --no-update
           composer update --prefer-dist --no-interaction
 
       - name: Wait for Redis Cluster to be ready

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/goopil/laravel-redis-sentinel/graph/badge.svg)](https://codecov.io/gh/goopil/laravel-redis-sentinel)
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![PHP Version](https://img.shields.io/badge/PHP-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue)](https://www.php.net/)
-[![Laravel](https://img.shields.io/badge/Laravel-10%20%7C%2011%20%7C%2012-red)](https://laravel.com/)
+[![Laravel](https://img.shields.io/badge/Laravel-10%20%7C%2011%20%7C%2012%20%7C%2013-red)](https://laravel.com/)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/goopil/laravel-redis-sentinel.svg)](https://packagist.org/packages/goopil/laravel-redis-sentinel)
 
 A Laravel package that adds Redis Sentinel support through the PhpRedis extension.
@@ -114,11 +114,11 @@ required.
 ## Requirements
 
 - **PHP**: ^8.2, ^8.3, ^8.4, ^8.5
-- **Laravel**: ^10, ^11, ^12
+- **Laravel**: ^10, ^11, ^12, ^13
 - **PHP Extension**: `redis` (PhpRedis)
 - **Optional**: [Laravel Horizon](https://laravel.com/docs/horizon) for queue management
 
-> ⚠️ **Important**: PHP 8.5 requires Laravel 12. Laravel 11 does not officially support PHP 8.5.
+> ⚠️ **Important**: PHP 8.5 requires Laravel 12 or 13. Laravel 11 does not officially support PHP 8.5. Laravel 13 requires PHP 8.3 or higher.
 > See [Laravel Support Matrix](https://laravel.com/docs/12.x/releases#support-policy) for details.
 
 ### Redis Setup
@@ -668,7 +668,7 @@ tests/
 The package includes a comprehensive GitHub Actions workflow that tests:
 
 - ✅ PHP 8.2, 8.3, 8.4, 8.5
-- ✅ Laravel 10, 11, 12
+- ✅ Laravel 10, 11, 12, 13
 - ✅ Redis 6, 7
 - ✅ **22 parallel test jobs** with isolated Redis Sentinel clusters
 - ✅ 342 tests with 2269 assertions

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
-        "laravel/framework": "^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "ext-redis": "*"
     },
     "require-dev": {
         "laravel/horizon": "^5.29",
         "laravel/pint": "^1.19",
-        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0 || ^11.0",
         "pestphp/pest": "^2.36 || ^3.7 || ^4.0",
         "pestphp/pest-plugin-laravel": "^2.2 || ^3.0 || ^4.0"
     },

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -139,10 +139,12 @@ class RedisSentinelServiceProvider extends ServiceProvider
 
     protected function bootBroadcaster(): void
     {
+        $name = $this->name;
+
         $this->app->make(BroadcastFactory::class)->extend(
-            $this->name,
+            $name,
             fn ($app, $conf) => new RedisBroadcaster(
-                $this->app->make($this->name),
+                $app->make($name),
                 Arr::get($conf, 'connection', 'default')
             )
         );
@@ -163,11 +165,14 @@ class RedisSentinelServiceProvider extends ServiceProvider
 
     protected function bootSessionHandler(): void
     {
+        $app = $this->app;
+        $name = $this->name;
+
         $this->app->make('session')->extend(
-            $this->name,
-            function () {
-                $config = $this->app->make('config');
-                $cacheDriver = clone $this->app->make('cache')->driver($this->name);
+            $name,
+            function () use ($app, $name) {
+                $config = $app->make('config');
+                $cacheDriver = clone $app->make('cache')->driver($name);
                 $cacheDriver->getStore()->setConnection($config->get('session.connection'));
 
                 return new CacheBasedSessionHandler(
@@ -197,9 +202,12 @@ class RedisSentinelServiceProvider extends ServiceProvider
             ? HorizonRedisConnector::class
             : RedisConnector::class;
 
-        $this->app->make('queue')->extend(
-            $this->name,
-            fn () => new $connector($this->app->make($this->name))
+        $name = $this->name;
+        $app = $this->app;
+
+        $app->make('queue')->extend(
+            $name,
+            fn () => new $connector($app->make($name))
         );
     }
 


### PR DESCRIPTION
## Laravel 13 support

- Update composer constraints to accept laravel/framework ^13.0 and orchestra/testbench ^11.0
- Fix Manager::extend callback rebinding in L13 across Session/Broadcast/Queue
  (callbacks now capture $app/$name via use() or short-closure auto-capture)
- Add Laravel 13 to CI matrix (php 8.3/8.4/8.5; excluded 8.2 + L13)
- Update Testbench resolver mapping with ^11.0 for L13
- Update README (badge, Requirements, PHP-version note, Supported list)

Tested against Laravel v13.x + PHP 8.4 + PhpRedis on a real 3-node Sentinel cluster:
341/344 pass. The 2 remaining failures are environment-specific (master service
name and live SENTINEL FAILOVER), not L13-related.

Octane integration (listener on Laravel\Octane\Events\RequestReceived) is
runtime-agnostic — Swoole/RoadRunner/FrankenPHP all work without extra wiring.