### PR TITLE
ci: add Codecov test analytics upload to test workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,11 +202,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: junit.xml
-          report-type: test_results
+          files: junit.xml
+          report_type: test_results
           flags: php-${{ matrix.php }},laravel-${{ matrix.laravel }},redis-${{ matrix.redis }}
           fail_ci_if_error: false
 
@@ -311,11 +311,11 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: junit.xml
-          report-type: test_results
+          files: junit.xml
+          report_type: test_results
           flags: php-8.4,laravel-12,redis-7,without-horizon
           fail_ci_if_error: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,7 +182,7 @@ jobs:
           echo "Redis Sentinel is ready!"
 
       - name: Execute tests
-        run: vendor/bin/pest --coverage-clover coverage.xml --min=50 --testdox
+        run: vendor/bin/pest --coverage-clover coverage.xml --min=50 --testdox --log-junit junit.xml
         env:
           REDIS_PASSWORD: test
           REDIS_SENTINEL_PASSWORD: test
@@ -198,6 +198,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: junit.xml
+          report-type: test_results
+          flags: php-${{ matrix.php }},laravel-${{ matrix.laravel }},redis-${{ matrix.redis }}
           fail_ci_if_error: false
 
       - name: Cleanup Redis Cluster
@@ -288,7 +298,7 @@ jobs:
           file_put_contents("without-horizon-tests.txt", implode(PHP_EOL, $files));
           '
 
-          vendor/bin/pest $(cat without-horizon-tests.txt) --testdox
+          vendor/bin/pest $(cat without-horizon-tests.txt) --testdox --log-junit junit.xml
         env:
           REDIS_PASSWORD: test
           REDIS_SENTINEL_PASSWORD: test
@@ -298,6 +308,16 @@ jobs:
           REDIS_STANDALONE_PORT: 7603
           REDIS_SENTINEL_PORT: 7604
           REDIS_SENTINEL_HOST: 127.0.0.1
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: junit.xml
+          report-type: test_results
+          flags: php-8.4,laravel-12,redis-7,without-horizon
+          fail_ci_if_error: false
 
       - name: Cleanup Redis Cluster
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v5
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: junit.xml
@@ -311,7 +311,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v5
+        uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 .phpunit.result.cache
 coverage/
 coverage.xml
+junit.xml
 .pest_coverage_cache
 composer.lock
 .worktrees/


### PR DESCRIPTION
## Summary

- Generate JUnit XML from Pest runs (`--log-junit junit.xml`) in both the matrix `tests` job and the `tests-without-horizon` job
- Upload test results to Codecov Test Analytics via `codecov/test-results-action@v5`, with `if: !cancelled()` so results are uploaded even when tests fail
- Tag uploads with per-dimension flags (`php-X`, `laravel-X`, `redis-X`, `without-horizon`) for environment filtering in the Codecov UI
- Ignore local `junit.xml` artifacts in `.gitignore`

Enables Codecov Test Analytics: test durations/failure rates on the Tests tab, PR comments with failed tests + stack traces, and flaky test detection. See [codecov docs](https://docs.codecov.com/docs/test-analytics).

## Validation plan

- [ ] "Upload test results to Codecov" steps pass on this PR (30 jobs)
- [ ] Codecov UI → Tests tab shows data, filterable by flags
- [ ] PR comment from Codecov confirms test report received