### PR TITLE
feat: emit worker lifecycle events in Horizon probe commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,49 @@ Events\RedisSentinelConnectionReconnected::class
 Events\RedisSentinelConnectionMaxRetryFailed::class
 ```
 
+### Horizon Worker Events
+
+The Kubernetes probe commands also dispatch worker lifecycle events:
+
+```php
+use Goopil\LaravelRedisSentinel\Events;
+
+// horizon:ready
+Events\HorizonWorkerReady::class;           // worker is ready (opt-in, see emit_success below)
+Events\HorizonWorkerNotReady::class;        // no running master supervisor found (always emitted)
+                                            // properties: $masters, $running
+
+// horizon:alive
+Events\HorizonWorkerAlive::class;           // all liveness checks pass (opt-in, see emit_success below)
+Events\HorizonWorkerNotAlive::class;        // one or more checks failed (always emitted)
+                                            // property: $failedChecks (check name => exit code)
+
+// horizon:pre-stop
+Events\HorizonWorkerTerminating::class;     // TERM signal sent to the master supervisor (opt-in, see emit_success below)
+                                            // properties: $pid, $startCommand
+Events\HorizonWorkerTerminateFailed::class; // TERM signal failed or PID not found (always emitted)
+                                            // properties: $startCommand, $pid (null when not found), $reason
+```
+
+Success events are disabled by default so probes stay quiet during normal operation. Enable them in
+`config/phpredis-sentinel.php`:
+
+```php
+'commands' => [
+    'events' => [
+        'emit_success' => env('REDIS_SENTINEL_EMIT_SUCCESS_EVENTS', false),
+    ],
+],
+```
+
+or by setting the environment variable:
+
+```env
+REDIS_SENTINEL_EMIT_SUCCESS_EVENTS=true
+```
+
+Failure events are always dispatched, regardless of this setting.
+
 ### Listening to Events
 
 ```php
@@ -750,6 +793,23 @@ class NotifyRedisFailure
 
         // Send to monitoring service
         // Sentry::captureException($event->exception);
+    }
+}
+
+// Horizon worker lifecycle example
+protected $listen = [
+    \Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotAlive::class => [
+        \App\Listeners\AlertHorizonUnhealthy::class,
+    ],
+];
+
+class AlertHorizonUnhealthy
+{
+    public function handle(HorizonWorkerNotAlive $event): void
+    {
+        Log::error('Horizon worker failed liveness checks', [
+            'failed_checks' => $event->failedChecks,
+        ]);
     }
 }
 ```

--- a/config/phpredis-sentinel.php
+++ b/config/phpredis-sentinel.php
@@ -12,6 +12,11 @@ return [
     'log' => [
         'channel' => env('REDIS_SENTINEL_LOG_CHANNEL', env('LOG_CHANNEL')),
     ],
+    'commands' => [
+        'events' => [
+            'emit_success' => env('REDIS_SENTINEL_EMIT_SUCCESS_EVENTS', false),
+        ],
+    ],
     'retry' => [
         'sentinel' => [
             'attempts' => 5,

--- a/src/Commands/HorizonWorkerLiveness.php
+++ b/src/Commands/HorizonWorkerLiveness.php
@@ -3,13 +3,17 @@
 namespace Goopil\LaravelRedisSentinel\Commands;
 
 use Carbon\Carbon;
+use Goopil\LaravelRedisSentinel\Concerns\EmitsWorkerEvents;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerAlive;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotAlive;
 use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Illuminate\Console\Command;
 use Throwable;
 
 class HorizonWorkerLiveness extends Command
 {
+    use EmitsWorkerEvents;
     use Loggable;
 
     /**
@@ -32,18 +36,24 @@ class HorizonWorkerLiveness extends Command
     public function handle(): int
     {
         $checks = [
-            $this->laravel->call([$this, 'checkSentinel']),
-            $this->laravel->call([$this, 'checkConnection']),
-            $this->call('horizon:ready'),
+            'sentinel' => $this->laravel->call([$this, 'checkSentinel']),
+            'connection' => $this->laravel->call([$this, 'checkConnection']),
+            'ready' => $this->call('horizon:ready'),
         ];
 
-        foreach ($checks as $check) {
-            if ($check !== 0) {
-                return 1;
-            }
+        $failedChecks = array_filter($checks, fn (int $exitCode) => $exitCode !== 0);
+
+        if ($failedChecks === []) {
+            $this->emitSuccessEvent(new HorizonWorkerAlive);
+
+            return 0;
         }
 
-        return 0;
+        $this->emitFailureEvent(new HorizonWorkerNotAlive(
+            failedChecks: $failedChecks,
+        ));
+
+        return 1;
     }
 
     public function checkSentinel(RedisSentinelManager $manager): int

--- a/src/Commands/HorizonWorkerPreStop.php
+++ b/src/Commands/HorizonWorkerPreStop.php
@@ -2,7 +2,10 @@
 
 namespace Goopil\LaravelRedisSentinel\Commands;
 
+use Goopil\LaravelRedisSentinel\Concerns\EmitsWorkerEvents;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerTerminateFailed;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerTerminating;
 use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Config\Repository as ConfigRepository;
@@ -12,6 +15,7 @@ use Symfony\Component\Process\Process;
 
 class HorizonWorkerPreStop extends Command
 {
+    use EmitsWorkerEvents;
     use Loggable;
 
     /**
@@ -75,14 +79,22 @@ class HorizonWorkerPreStop extends Command
             ));
 
             if (! posix_kill($pid, SIGTERM)) {
+                $error = posix_strerror(posix_get_last_error());
+
                 $this->error(
                     sprintf(
                         'Failed to kill command:%s with process: {%s} (%s)',
                         $startCommand,
                         $pid,
-                        posix_strerror(posix_get_last_error())
+                        $error
                     )
                 );
+
+                $this->emitFailureEvent(new HorizonWorkerTerminateFailed(
+                    startCommand: $startCommand,
+                    pid: $pid,
+                    reason: $error,
+                ));
             } else {
                 $this->info(
                     sprintf(
@@ -91,11 +103,22 @@ class HorizonWorkerPreStop extends Command
                         $pid,
                     )
                 );
+
+                $this->emitSuccessEvent(new HorizonWorkerTerminating(
+                    pid: $pid,
+                    startCommand: $startCommand,
+                ));
             }
         } else {
             $this->error(sprintf(
                 'failed to find command %s pid',
                 $startCommand
+            ));
+
+            $this->emitFailureEvent(new HorizonWorkerTerminateFailed(
+                startCommand: $startCommand,
+                pid: $pid ?: null,
+                reason: sprintf('failed to find command %s pid', $startCommand),
             ));
         }
 

--- a/src/Commands/HorizonWorkerReadiness.php
+++ b/src/Commands/HorizonWorkerReadiness.php
@@ -2,12 +2,16 @@
 
 namespace Goopil\LaravelRedisSentinel\Commands;
 
+use Goopil\LaravelRedisSentinel\Concerns\EmitsWorkerEvents;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotReady;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerReady;
 use Illuminate\Console\Command;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
 
 class HorizonWorkerReadiness extends Command
 {
+    use EmitsWorkerEvents;
     use Loggable;
 
     /**
@@ -35,16 +39,25 @@ class HorizonWorkerReadiness extends Command
             );
 
         if ($result->count() === 1) {
+            $this->emitSuccessEvent(new HorizonWorkerReady);
+
             return 0;
         }
+
+        $all = $masters->all();
 
         $this->log(
             ' current master is not ready',
             [
                 'current' => $result->toArray(),
-                'masters' => $masters->all(),
+                'masters' => $all,
             ]
         );
+
+        $this->emitFailureEvent(new HorizonWorkerNotReady(
+            masters: $all,
+            running: $result->values()->all(),
+        ));
 
         return 1;
     }

--- a/src/Concerns/EmitsWorkerEvents.php
+++ b/src/Concerns/EmitsWorkerEvents.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Concerns;
+
+trait EmitsWorkerEvents
+{
+    protected function emitSuccessEvent(object $event): void
+    {
+        if (config('phpredis-sentinel.commands.events.emit_success') === true) {
+            event($event);
+        }
+    }
+
+    protected function emitFailureEvent(object $event): void
+    {
+        event($event);
+    }
+}

--- a/src/Concerns/EmitsWorkerEvents.php
+++ b/src/Concerns/EmitsWorkerEvents.php
@@ -2,17 +2,30 @@
 
 namespace Goopil\LaravelRedisSentinel\Concerns;
 
+use Throwable;
+
 trait EmitsWorkerEvents
 {
     protected function emitSuccessEvent(object $event): void
     {
-        if (config('phpredis-sentinel.commands.events.emit_success') === true) {
-            event($event);
+        // env() keeps "1" as a string, so parse the value instead of comparing to true.
+        if (filter_var(config('phpredis-sentinel.commands.events.emit_success'), FILTER_VALIDATE_BOOLEAN)) {
+            // Kubernetes probes must keep their exit code even if a listener throws.
+            try {
+                event($event);
+            } catch (Throwable $e) {
+                report($e);
+            }
         }
     }
 
     protected function emitFailureEvent(object $event): void
     {
-        event($event);
+        // Kubernetes probes must keep their exit code even if a listener throws.
+        try {
+            event($event);
+        } catch (Throwable $e) {
+            report($e);
+        }
     }
 }

--- a/src/Events/HorizonWorkerAlive.php
+++ b/src/Events/HorizonWorkerAlive.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerAlive
+{
+    use Dispatchable;
+    use SerializesModels;
+}

--- a/src/Events/HorizonWorkerNotAlive.php
+++ b/src/Events/HorizonWorkerNotAlive.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerNotAlive
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly array $failedChecks,
+    ) {}
+}

--- a/src/Events/HorizonWorkerNotReady.php
+++ b/src/Events/HorizonWorkerNotReady.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerNotReady
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly array $masters,
+        public readonly array $running,
+    ) {}
+}

--- a/src/Events/HorizonWorkerReady.php
+++ b/src/Events/HorizonWorkerReady.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerReady
+{
+    use Dispatchable;
+    use SerializesModels;
+}

--- a/src/Events/HorizonWorkerTerminateFailed.php
+++ b/src/Events/HorizonWorkerTerminateFailed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerTerminateFailed
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $startCommand,
+        public readonly ?int $pid,
+        public readonly string $reason,
+    ) {}
+}

--- a/src/Events/HorizonWorkerTerminating.php
+++ b/src/Events/HorizonWorkerTerminating.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class HorizonWorkerTerminating
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $pid,
+        public readonly string $startCommand,
+    ) {}
+}

--- a/tests/Feature/Horizon/HorizonCommandEventsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandEventsTest.php
@@ -82,6 +82,24 @@ describe('Horizon Command Events', function () {
         Event::assertDispatched(HorizonWorkerReady::class);
     });
 
+    test('horizon:ready emits HorizonWorkerReady when emit_success is set to "1"', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        config(['phpredis-sentinel.commands.events.emit_success' => '1']);
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mock->expects('all')->andReturn([horizonEventsRunningMaster()]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+
+        expect($exitCode)->toBe(0);
+
+        Event::assertDispatched(HorizonWorkerReady::class);
+    });
+
     test('horizon:ready always emits HorizonWorkerNotReady on failure with masters context', function () {
         if (! interface_exists(MasterSupervisorRepository::class)) {
             $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
@@ -102,6 +120,36 @@ describe('Horizon Command Events', function () {
         Event::assertDispatched(HorizonWorkerNotReady::class, function (HorizonWorkerNotReady $event) use ($master) {
             return $event->masters === [$master] && $event->running === [];
         });
+    });
+
+    test('a throwing listener does not change the probe exit code', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        // Reach real listeners: unwrap the fake dispatcher registered in beforeEach.
+        $dispatcher = Event::getFacadeRoot()->dispatcher;
+        Event::swap($dispatcher);
+
+        $listenerInvoked = false;
+        Event::listen(HorizonWorkerNotReady::class, function (HorizonWorkerNotReady $event) use (&$listenerInvoked): void {
+            $listenerInvoked = true;
+
+            throw new RuntimeException('listener failed');
+        });
+
+        $master = new MasterSupervisor;
+        $master->name = gethostname().':1';
+        $master->status = 'paused';
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($master) {
+            $mock->expects('all')->twice()->andReturn([$master]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+
+        expect($exitCode)->toBe(1)
+            ->and($listenerInvoked)->toBeTrue();
     });
 
     test('horizon:alive emits no event by default', function () {

--- a/tests/Feature/Horizon/HorizonCommandEventsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandEventsTest.php
@@ -1,0 +1,245 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerAlive;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotAlive;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotReady;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerReady;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerTerminateFailed;
+use Goopil\LaravelRedisSentinel\Events\HorizonWorkerTerminating;
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
+use Illuminate\Redis\Connections\PhpRedisConnection;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
+use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\HorizonServiceProvider;
+use Laravel\Horizon\MasterSupervisor;
+use Mockery\MockInterface;
+use Symfony\Component\Process\Process;
+
+const HORIZON_EVENTS_NOT_INSTALLED = 'Horizon not installed';
+
+function horizonEventsRunningMaster(): MasterSupervisor
+{
+    $master = new MasterSupervisor;
+    $master->name = gethostname().':1';
+    $master->status = 'running';
+
+    return $master;
+}
+
+describe('Horizon Command Events', function () {
+    beforeEach(function () {
+        if (class_exists(HorizonServiceProvider::class)) {
+            app()->register(HorizonServiceProvider::class);
+        }
+
+        config(['horizon.driver' => 'phpredis-sentinel']);
+        config(['horizon.use' => 'phpredis-sentinel']);
+        config(['database.redis.horizon' => config('database.redis.phpredis-sentinel')]);
+
+        app()->forgetInstance(RedisSentinelManager::class);
+        app()->forgetInstance('redis');
+
+        // Re-register the connector on the new manager
+        $manager = app(RedisSentinelManager::class);
+        $manager->extend('phpredis-sentinel', function () {
+            return app('redis.sentinel');
+        });
+
+        Event::fake();
+    });
+
+    test('horizon:ready emits no success event by default', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mock->expects('all')->andReturn([horizonEventsRunningMaster()]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+
+        expect($exitCode)->toBe(0)
+            ->and(Event::assertNotDispatched(HorizonWorkerReady::class));
+    });
+
+    test('horizon:ready emits HorizonWorkerReady when emit_success is enabled', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        config(['phpredis-sentinel.commands.events.emit_success' => true]);
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mock->expects('all')->andReturn([horizonEventsRunningMaster()]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+
+        expect($exitCode)->toBe(0);
+
+        Event::assertDispatched(HorizonWorkerReady::class);
+    });
+
+    test('horizon:ready always emits HorizonWorkerNotReady on failure with masters context', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        $master = new MasterSupervisor;
+        $master->name = gethostname().':1';
+        $master->status = 'paused';
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($master) {
+            $mock->expects('all')->twice()->andReturn([$master]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+
+        expect($exitCode)->toBe(1);
+
+        Event::assertDispatched(HorizonWorkerNotReady::class, function (HorizonWorkerNotReady $event) use ($master) {
+            return $event->masters === [$master] && $event->running === [];
+        });
+    });
+
+    test('horizon:alive emits no event by default', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        config(['horizon.use' => 'phpredis-sentinel']);
+        config(['database.redis.phpredis-sentinel.sentinel.service' => 'master']);
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mock->expects('all')->andReturn([horizonEventsRunningMaster()]);
+        });
+
+        $exitCode = Artisan::call('horizon:alive');
+
+        expect($exitCode)->toBe(0)
+            ->and(Event::assertNotDispatched(HorizonWorkerAlive::class));
+    });
+
+    test('horizon:alive emits HorizonWorkerAlive when emit_success is enabled', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        config([
+            'phpredis-sentinel.commands.events.emit_success' => true,
+            'horizon.use' => 'phpredis-sentinel',
+            'database.redis.phpredis-sentinel.sentinel.service' => 'master',
+        ]);
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mock->expects('all')->andReturn([horizonEventsRunningMaster()]);
+        });
+
+        $exitCode = Artisan::call('horizon:alive');
+
+        expect($exitCode)->toBe(0);
+
+        Event::assertDispatched(HorizonWorkerAlive::class);
+    });
+
+    test('horizon:alive always emits HorizonWorkerNotAlive with failed checks on failure', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        config(['horizon.use' => 'phpredis-sentinel']);
+        config(['database.redis.phpredis-sentinel.sentinel.service' => 'master']);
+
+        // Build the master before mocking the manager: MasterSupervisor's
+        // constructor flushes Horizon's command queue through the redis manager.
+        $master = horizonEventsRunningMaster();
+
+        $connection = Mockery::mock(PhpRedisConnection::class);
+        $connection->allows('set')->andReturnTrue();
+
+        $this->mock(RedisSentinelManager::class, function (MockInterface $mock) use ($connection) {
+            $mock->allows('resolveConnector')->andThrow(new RuntimeException('sentinel unavailable'));
+            $mock->allows('resolve')->andReturn($connection);
+        });
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($master) {
+            $mock->expects('all')->andReturn([$master]);
+        });
+
+        $exitCode = Artisan::call('horizon:alive');
+
+        expect($exitCode)->toBe(1);
+
+        Event::assertDispatched(HorizonWorkerNotAlive::class, function (HorizonWorkerNotAlive $event) {
+            return $event->failedChecks === ['sentinel' => 1];
+        });
+    });
+
+    test('horizon:pre-stop emits HorizonWorkerTerminateFailed when no process is found', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl or posix extension not loaded');
+        }
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $master = new MasterSupervisor;
+            $master->name = gethostname().':1';
+            $master->pid = 999999; // Non-existent PID likely
+
+            $mock->expects('all')->andReturn([$master]);
+        });
+
+        $exitCode = Artisan::call('horizon:pre-stop', ['--start-command' => 'php artisan horizon']);
+
+        expect($exitCode)->toBe(0);
+
+        Event::assertDispatched(HorizonWorkerTerminateFailed::class, function (HorizonWorkerTerminateFailed $event) {
+            return $event->pid === 999999
+                && $event->startCommand === 'php artisan horizon'
+                && $event->reason !== '';
+        });
+
+        Event::assertNotDispatched(HorizonWorkerTerminating::class);
+    });
+
+    test('horizon:pre-stop emits HorizonWorkerTerminating when TERM signal is sent', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl or posix extension not loaded');
+        }
+
+        config(['phpredis-sentinel.commands.events.emit_success' => true]);
+
+        $process = Process::fromShellCommandline('sleep 5 & echo $!');
+        $process->run();
+        $pid = (int) trim($process->getOutput());
+
+        expect($pid)->toBeGreaterThan(0);
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($pid) {
+            $master = new MasterSupervisor;
+            $master->name = gethostname().':1';
+            $master->pid = $pid;
+
+            $mock->expects('all')->andReturn([$master]);
+        });
+
+        $exitCode = Artisan::call('horizon:pre-stop', ['--start-command' => 'sleep 5']);
+
+        expect($exitCode)->toBe(0);
+
+        Event::assertDispatched(HorizonWorkerTerminating::class, function (HorizonWorkerTerminating $event) use ($pid) {
+            return $event->pid === $pid && $event->startCommand === 'sleep 5';
+        });
+
+        Event::assertNotDispatched(HorizonWorkerTerminateFailed::class);
+    });
+});


### PR DESCRIPTION
Closes #4

## Summary

- Emit Laravel events from the three Kubernetes probe commands (`horizon:ready`, `horizon:alive`, `horizon:pre-stop`) so users can hook on worker state changes (alerting, metrics, notifications)
- 6 new event classes in `Goopil\LaravelRedisSentinel\Events`: `HorizonWorkerReady`, `HorizonWorkerNotReady`, `HorizonWorkerAlive`, `HorizonWorkerNotAlive`, `HorizonWorkerTerminating`, `HorizonWorkerTerminateFailed`
- New `Concerns\EmitsWorkerEvents` trait: failure events are always dispatched; success events are opt-in via `phpredis-sentinel.commands.events.emit_success` (default off — probes run frequently and success events would be noisy)
- New config block in `config/phpredis-sentinel.php` with `REDIS_SENTINEL_EMIT_SUCCESS_EVENTS` env override
- README: Events section extended with the worker lifecycle events, listener example, and config flag

## Design notes

- Dispatch is wrapped in `try/catch` + `report()`: a throwing user listener can never flip a probe's exit code in Kubernetes (a failing pre-stop hook must not block pod shutdown)
- The gate uses `filter_var(..., FILTER_VALIDATE_BOOLEAN)` instead of `config()->boolean()`: the latter throws `InvalidArgumentException` on `'1'` in laravel/framework 13.29, which would fatal the probe for exactly the value users set
- Exit codes, console output, and all command signatures are unchanged — fully backward compatible

## Testing

- New `tests/Feature/Horizon/HorizonCommandEventsTest.php` (10 tests): all brief-mandated cases, including a real `sleep` process for the pre-stop success path and a throwing-listener exit-code stability test
- Full suite: 414 passed, 1 pre-existing environmental skip, 0 failed; `composer lint` clean
