### PR TITLE
feat: add valkey test bench for wire compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -376,11 +376,12 @@ jobs:
           VALKEY_REPLICA1_PORT: 7701
           VALKEY_REPLICA2_PORT: 7702
           VALKEY_SENTINEL_PORT: 7703
+          VALKEY_STANDALONE_PORT: 7704
           COMPOSE_PROJECT_NAME: redis_valkey
           SENTINEL_EXTRA_CONFIG: "echo 'sentinel resolve-hostnames yes' >> /tmp/sentinel.conf && echo 'sentinel announce-hostnames yes' >> /tmp/sentinel.conf &&"
         run: |
-          echo "Starting Valkey cluster on ports: Main=$VALKEY_MAIN_PORT, Replica1=$VALKEY_REPLICA1_PORT, Replica2=$VALKEY_REPLICA2_PORT, Sentinel=$VALKEY_SENTINEL_PORT"
-          SENTINEL_EXTRA_CONFIG="$SENTINEL_EXTRA_CONFIG" docker compose -f tests/ci/docker-compose.yml up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel
+          echo "Starting Valkey cluster on ports: Main=$VALKEY_MAIN_PORT, Replica1=$VALKEY_REPLICA1_PORT, Replica2=$VALKEY_REPLICA2_PORT, Sentinel=$VALKEY_SENTINEL_PORT, Standalone=$VALKEY_STANDALONE_PORT"
+          SENTINEL_EXTRA_CONFIG="$SENTINEL_EXTRA_CONFIG" docker compose -f tests/ci/docker-compose.yml up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel valkey
 
       - name: Wait for Valkey Cluster to be ready
         run: |
@@ -399,7 +400,7 @@ jobs:
           REDIS_PREFIX: gh_${{ github.run_id }}_valkey_
           REDIS_HOST: 127.0.0.1
           REDIS_PORT: 7700
-          REDIS_STANDALONE_PORT: 7700
+          REDIS_STANDALONE_PORT: 7704
           REDIS_SENTINEL_PORT: 7703
           REDIS_SENTINEL_HOST: 127.0.0.1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -331,3 +331,81 @@ jobs:
           COMPOSE_PROJECT_NAME: redis_without_horizon
         run: |
           docker compose -f tests/ci/docker-compose.yml down -v --remove-orphans || true
+
+  tests-valkey:
+    needs: [lint]
+    runs-on: ubuntu-latest
+
+    name: PHP 8.4 - L12 - Valkey
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, readline, ldap, msgpack, igbinary, redis, sodium
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.4-laravel-12-valkey-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-laravel-12-valkey-
+            ${{ runner.os }}-php-8.4-
+
+      - name: Install dependencies
+        run: |
+          composer config policy.advisories.block false
+          composer require "laravel/framework:12.*" "orchestra/testbench:^10.0" --dev --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Start Valkey Sentinel Cluster
+        env:
+          VALKEY_VERSION: 8
+          VALKEY_MAIN_PORT: 7700
+          VALKEY_REPLICA1_PORT: 7701
+          VALKEY_REPLICA2_PORT: 7702
+          VALKEY_SENTINEL_PORT: 7703
+          COMPOSE_PROJECT_NAME: redis_valkey
+          SENTINEL_EXTRA_CONFIG: "echo 'sentinel resolve-hostnames yes' >> /tmp/sentinel.conf && echo 'sentinel announce-hostnames yes' >> /tmp/sentinel.conf &&"
+        run: |
+          echo "Starting Valkey cluster on ports: Main=$VALKEY_MAIN_PORT, Replica1=$VALKEY_REPLICA1_PORT, Replica2=$VALKEY_REPLICA2_PORT, Sentinel=$VALKEY_SENTINEL_PORT"
+          SENTINEL_EXTRA_CONFIG="$SENTINEL_EXTRA_CONFIG" docker compose -f tests/ci/docker-compose.yml up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel
+
+      - name: Wait for Valkey Cluster to be ready
+        run: |
+          echo "Waiting for Valkey cluster on sentinel port 7703..."
+          until docker run --network host --rm valkey/valkey:8-alpine valkey-cli -p 7703 -a test ping | grep -q PONG; do
+            echo "Valkey Sentinel not ready yet..."
+            sleep 2
+          done
+          echo "Valkey Sentinel is ready!"
+
+      - name: Execute tests
+        run: vendor/bin/pest --testdox
+        env:
+          REDIS_PASSWORD: test
+          REDIS_SENTINEL_PASSWORD: test
+          REDIS_PREFIX: gh_${{ github.run_id }}_valkey_
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 7700
+          REDIS_STANDALONE_PORT: 7700
+          REDIS_SENTINEL_PORT: 7703
+          REDIS_SENTINEL_HOST: 127.0.0.1
+
+      - name: Cleanup Valkey Cluster
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: redis_valkey
+        run: |
+          docker compose -f tests/ci/docker-compose.yml down -v --remove-orphans || true

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ required.
 - Redis Sentinel cluster (minimum 3 nodes recommended)
 - Redis version 6.0 or higher recommended
 
+### Valkey Compatibility
+
+[Valkey](https://valkey.io/) is wire-compatible with Redis and is supported out of the box. Compatibility is validated by
+the automated test bench: a Valkey 8 Sentinel cluster runs the full test suite in CI (the `tests-valkey` job) and can be
+run locally through the Docker environment (see [Local Development](#local-development)).
+
 ## Installation
 
 ### 1. Install via Composer
@@ -850,6 +856,7 @@ The package includes a comprehensive GitHub Actions workflow that tests:
 - ✅ PHP 8.2, 8.3, 8.4, 8.5
 - ✅ Laravel 10, 11, 12, 13
 - ✅ Redis 6, 7
+- ✅ Valkey 8 (dedicated `tests-valkey` job)
 - ✅ Linting before the test matrix
 - ✅ **Matrix test jobs** across isolated Redis Sentinel clusters
 - ✅ A dedicated PHP 8.4 / Laravel 12 job without Horizon installed
@@ -883,6 +890,22 @@ redis-cli -h 127.0.0.1 -p 26379 -a test
 
 # Check sentinel status
 redis-cli -h 127.0.0.1 -p 26379 -a test sentinel masters
+```
+
+### Running Tests Against Valkey
+
+The Docker environment also includes a Valkey 8 Sentinel cluster (wire-compatible with Redis) on dedicated ports:
+
+- 1 Valkey Master (port 6385)
+- 2 Valkey Replicas (ports 6386, 6387)
+- 1 Valkey Sentinel (port 26380)
+
+Start the Valkey services and run the test suite against them:
+
+```bash
+docker compose up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel
+
+REDIS_SENTINEL_PORT=26380 REDIS_STANDALONE_PORT=6385 vendor/bin/pest
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -899,13 +899,14 @@ The Docker environment also includes a Valkey 8 Sentinel cluster (wire-compatibl
 - 1 Valkey Master (port 6385)
 - 2 Valkey Replicas (ports 6386, 6387)
 - 1 Valkey Sentinel (port 26380)
+- 1 standalone Valkey (port 6388) used by the plain `redis` connection, kept out of the Sentinel topology
 
 Start the Valkey services and run the test suite against them:
 
 ```bash
-docker compose up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel
+docker compose up -d valkey-main valkey-replica1 valkey-replica2 valkey-sentinel valkey
 
-REDIS_SENTINEL_PORT=26380 REDIS_STANDALONE_PORT=6385 vendor/bin/pest
+REDIS_SENTINEL_PORT=26380 REDIS_STANDALONE_PORT=6388 vendor/bin/pest
 ```
 
 ## Troubleshooting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,3 +75,69 @@ services:
       test: [ "CMD", "redis-cli", "-p", "6379", "-a", "test", "ping" ]
       retries: 3
       timeout: 5s
+
+  valkey-main:
+    image: 'valkey/valkey:8-alpine'
+    command: 'valkey-server --requirepass "test" --masterauth "test" --port 6385 --replica-announce-ip 127.0.0.1'
+    network_mode: host
+    ports:
+      - '6385:6385'
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "6385", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s
+    depends_on: []
+
+  valkey-replica1:
+    image: 'valkey/valkey:8-alpine'
+    command: 'valkey-server --slaveof 127.0.0.1 6385 --requirepass "test" --masterauth "test" --port 6386 --replica-announce-ip 127.0.0.1'
+    network_mode: host
+    ports:
+      - '6386:6386'
+    depends_on:
+      - valkey-main
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "6386", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s
+
+  valkey-replica2:
+    image: 'valkey/valkey:8-alpine'
+    network_mode: host
+    command: 'valkey-server --slaveof 127.0.0.1 6385 --requirepass "test" --masterauth "test" --port 6387 --replica-announce-ip 127.0.0.1'
+    ports:
+      - '6387:6387'
+    depends_on:
+      - valkey-main
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "6387", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s
+
+  valkey-sentinel:
+    image: 'valkey/valkey:8-alpine'
+    network_mode: host
+    ports:
+      - '26380:26380'
+    command:
+      - "sh"
+      - "-c"
+      - "echo 'port 26380' > /tmp/sentinel.conf && \
+         echo 'sentinel monitor master 127.0.0.1 6385 2' >> /tmp/sentinel.conf && \
+         echo 'sentinel resolve-hostnames yes' >> /tmp/sentinel.conf && \
+         echo 'sentinel announce-hostnames yes' >> /tmp/sentinel.conf && \
+         echo 'sentinel auth-pass master test' >> /tmp/sentinel.conf && \
+         echo 'requirepass test' >> /tmp/sentinel.conf && \
+         echo 'sentinel down-after-milliseconds master 5000' >> /tmp/sentinel.conf && \
+         echo 'sentinel parallel-syncs master 1' >> /tmp/sentinel.conf && \
+         echo 'sentinel failover-timeout master 60000' >> /tmp/sentinel.conf && \
+         cat /tmp/sentinel.conf && \
+         valkey-sentinel /tmp/sentinel.conf"
+    depends_on:
+      - valkey-main
+      - valkey-replica1
+      - valkey-replica2
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "26380", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,3 +141,14 @@ services:
       test: [ "CMD", "valkey-cli", "-p", "26380", "-a", "test", "ping" ]
       retries: 3
       timeout: 5s
+
+  valkey:
+    image: 'valkey/valkey:8-alpine'
+    network_mode: host
+    command: valkey-server --requirepass "test" --port 6388
+    ports:
+      - '6388:6388'
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "6388", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s

--- a/src/Commands/HorizonWorkerPreStop.php
+++ b/src/Commands/HorizonWorkerPreStop.php
@@ -117,7 +117,7 @@ class HorizonWorkerPreStop extends Command
 
             $this->emitFailureEvent(new HorizonWorkerTerminateFailed(
                 startCommand: $startCommand,
-                pid: $pid ?: null,
+                pid: null,
                 reason: sprintf('failed to find command %s pid', $startCommand),
             ));
         }

--- a/src/Events/HorizonWorkerNotAlive.php
+++ b/src/Events/HorizonWorkerNotAlive.php
@@ -10,6 +10,9 @@ class HorizonWorkerNotAlive
     use Dispatchable;
     use SerializesModels;
 
+    /**
+     * @param  array<string, int>  $failedChecks
+     */
     public function __construct(
         public readonly array $failedChecks,
     ) {}

--- a/src/Events/HorizonWorkerNotReady.php
+++ b/src/Events/HorizonWorkerNotReady.php
@@ -10,6 +10,10 @@ class HorizonWorkerNotReady
     use Dispatchable;
     use SerializesModels;
 
+    /**
+     * @param  array<int, object>  $masters
+     * @param  array<int, object>  $running
+     */
     public function __construct(
         public readonly array $masters,
         public readonly array $running,

--- a/tests/ci/docker-compose.yml
+++ b/tests/ci/docker-compose.yml
@@ -58,3 +58,54 @@ services:
       test: [ "CMD", "redis-cli", "-p", "${REDIS_STANDALONE_PORT:-6379}", "-a", "test", "ping" ]
       retries: 3
       timeout: 5s
+
+  valkey-main:
+    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    command: valkey-server --requirepass "test" --masterauth "test" --port ${VALKEY_MAIN_PORT:-6385} --replica-announce-ip 127.0.0.1
+    network_mode: host
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "${VALKEY_MAIN_PORT:-6385}", "-a", "test", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  valkey-replica1:
+    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    command: valkey-server --slaveof 127.0.0.1 ${VALKEY_MAIN_PORT:-6385} --requirepass "test" --masterauth "test" --port ${VALKEY_REPLICA1_PORT:-6386} --replica-announce-ip 127.0.0.1
+    network_mode: host
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "${VALKEY_REPLICA1_PORT:-6386}", "-a", "test", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  valkey-replica2:
+    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    command: valkey-server --slaveof 127.0.0.1 ${VALKEY_MAIN_PORT:-6385} --requirepass "test" --masterauth "test" --port ${VALKEY_REPLICA2_PORT:-6387} --replica-announce-ip 127.0.0.1
+    network_mode: host
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "${VALKEY_REPLICA2_PORT:-6387}", "-a", "test", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  valkey-sentinel:
+    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    network_mode: host
+    environment:
+      - SENTINEL_EXTRA_CONFIG=${SENTINEL_EXTRA_CONFIG:-}
+    command: >
+      sh -c "echo 'port ${VALKEY_SENTINEL_PORT:-26380}' > /tmp/sentinel.conf &&
+      echo 'sentinel monitor master 127.0.0.1 ${VALKEY_MAIN_PORT:-6385} 2' >> /tmp/sentinel.conf &&
+      echo 'sentinel auth-pass master test' >> /tmp/sentinel.conf &&
+      echo 'requirepass test' >> /tmp/sentinel.conf &&
+      $SENTINEL_EXTRA_CONFIG
+      echo 'sentinel down-after-milliseconds master 5000' >> /tmp/sentinel.conf &&
+      echo 'sentinel parallel-syncs master 1' >> /tmp/sentinel.conf &&
+      echo 'sentinel failover-timeout master 60000' >> /tmp/sentinel.conf &&
+      valkey-sentinel /tmp/sentinel.conf"
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "${VALKEY_SENTINEL_PORT:-26380}", "-a", "test", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/tests/ci/docker-compose.yml
+++ b/tests/ci/docker-compose.yml
@@ -109,3 +109,12 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+
+  valkey:
+    image: valkey/valkey:${VALKEY_VERSION:-8}-alpine
+    network_mode: host
+    command: valkey-server --requirepass "test" --port ${VALKEY_STANDALONE_PORT:-6388}
+    healthcheck:
+      test: [ "CMD", "valkey-cli", "-p", "${VALKEY_STANDALONE_PORT:-6388}", "-a", "test", "ping" ]
+      retries: 3
+      timeout: 5s


### PR DESCRIPTION
Closes #5

## Summary

- Add a Valkey cluster to the test bench to validate wire compatibility of the package against Valkey (master + 2 replicas + Sentinel) — test infrastructure only, no package code changes
- **Root `docker-compose.yml`**: four Valkey services mirroring the Redis ones (image `valkey/valkey:8-alpine`, password `test`, ports 6385/6386/6387, Sentinel on 26380), native `valkey-server`/`valkey-sentinel`/`valkey-cli` binaries
- **`tests/ci/docker-compose.yml`**: same services driven by `VALKEY_MAIN_PORT`/`VALKEY_REPLICA1_PORT`/`VALKEY_REPLICA2_PORT`/`VALKEY_SENTINEL_PORT`/`VALKEY_VERSION` env vars
- **`.github/workflows/tests.yml`**: dedicated `tests-valkey` job (PHP 8.4 / Laravel 12, full suite incl. Horizon) that starts only the Valkey services on ports 7700-7703 and points the `REDIS_*` test env at the Valkey cluster
- **README**: Valkey compatibility section + how to run the suite against Valkey locally

## Notes

- A full `server: [redis, valkey]` matrix dimension was considered and rejected: it would double the CI matrix (~30 jobs) for a wire-compatibility check; a dedicated job keeps the signal with minimal cost
- Known follow-ups (documented, non-blocking): a standalone `valkey` service (the plain connection currently shares the sentinel-monitored master), and `timeout-minutes` on workflow jobs
- The CI job's first real run happens on this PR — its structure is a faithful clone of the `tests-without-horizon` job

## Testing

- Local Valkey cluster verified: sentinel resolves master, full suite vs Valkey green (74/74 affected files in isolated run), plain-redis regression 404/404, `composer lint` clean
