### PR TITLE
ci: restrict dependabot auto-merge to patch and minor updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,19 +13,33 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: Merge dependabot PRs older than 7 days with green CI
+      - name: Merge patch/minor dependabot PRs older than 7 days with green CI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          prs=$(gh pr list --label dependencies --state open --limit 50 \
-            --json number,author,createdAt \
-            --jq '.[] | select(.author.login=="dependabot[bot]" and ((now - (.createdAt|fromdateiso8601)) > 604800)) | .number')
-          if [ -z "$prs" ]; then
+          gh pr list --label dependencies --state open --limit 50 \
+            --json number,author,createdAt,title \
+            --jq '.[] | select(.author.login=="dependabot[bot]" and ((now - (.createdAt|fromdateiso8601)) > 604800)) | "\(.number)\t\(.title)"' > /tmp/prs.txt
+          if [ ! -s /tmp/prs.txt ]; then
             echo "No dependabot PRs older than 7 days."
             exit 0
           fi
-          for pr in $prs; do
+          while IFS=$'\t' read -r pr title; do
+            [ -z "$pr" ] && continue
+            from=$(echo "$title" | grep -oE 'from [0-9][^ ]*' | awk '{print $2}')
+            to=$(echo "$title" | grep -oE ' to [0-9][^ ]*' | awk '{print $2}')
+            if [[ "$title" == *"minor-and-patch group"* ]]; then
+              bump=patch-or-minor
+            elif [ -n "$from" ] && [ -n "$to" ] && [ "${from%%.*}" = "${to%%.*}" ]; then
+              bump=patch-or-minor
+            else
+              bump=major-or-unknown
+            fi
+            if [ "$bump" != "patch-or-minor" ]; then
+              echo "Skipping PR #$pr (major or unrecognized bump, manual review required): $title"
+              continue
+            fi
             echo "Auto-merging PR #$pr"
             gh pr merge "$pr" --squash --auto || gh pr merge "$pr" --squash || echo "Could not merge PR #$pr, skipping"
-          done
+          done < /tmp/prs.txt

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,6 +13,9 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Merge patch/minor dependabot PRs older than 7 days with green CI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Dependabot auto-merge (scheduled daily, 7-day delay) now only merges **patch and minor** bumps; **major** bumps are skipped with an explicit log line and require manual review
- Classification is derived from the PR title: `bump X from A to B` (major = different first semver digit), plus recognition of grouped `minor-and-patch` PRs opened by our `dependabot.yml` group config (they are patch/minor by construction)
- Unrecognized titles (e.g. unexpected formats) are also skipped rather than merged — fail-closed

## Why

The current workflow auto-merges *any* dependabot PR (including majors) after 7 days with green CI. A major bump of a release-tooling package (e.g. `semantic-release` plugins) could silently land and break the release pipeline while looking routine.

## Verification

- YAML validated
- Classification logic tested against real PR titles: major (6→7) → skip, minor (7→7) → merge, patch (7→5→7.5.18) → merge, security major (1→2) → skip, grouped `minor-and-patch` → merge
- Full loop simulation over the two currently open major PRs (#32, #33) → both correctly skipped

## Consequence for open PRs

#32 and #33 (major bumps of `@semantic-release/changelog` and `@semantic-release/git`) are no longer eligible for auto-merge — they become manual merge decisions (CI is green on both).