### PR TITLE
test: harden chaos failover tests against proxy listener warm-up refusals

### DIFF
--- a/tests/Feature/Toxiproxy/FailoverTest.php
+++ b/tests/Feature/Toxiproxy/FailoverTest.php
@@ -19,7 +19,13 @@ describe('Real Sentinel failover through toxiproxy', function () {
 
         expect($newAddress['port'])->not->toBe($oldAddress['port']);
 
-        expect($this->reissueUntilSuccess(fn () => $connection->set('chaos_failover', 'after')))->toBeTrue()
+        // On CI, host port forwarding can refuse connects for several seconds after a
+        // proxy listener is (re)created, even past a first successful probe - the
+        // failover below promotes a node whose proxy is freshly recreated, so re-verify
+        // traffic and give the retry a wide window before reissuing writes
+        $this->waitForProxyReady($newAddress['port'], 10);
+
+        expect($this->reissueUntilSuccess(fn () => $connection->set('chaos_failover', 'after'), attempts: 20))->toBeTrue()
             ->and($connection->get('chaos_failover'))->toBe('after');
 
         Event::assertDispatched(RedisSentinelConnectionReconnected::class);
@@ -43,8 +49,13 @@ describe('Real Sentinel failover through toxiproxy', function () {
 
         // Reuse the SAME connection object: its established client still points at the
         // cut master, so the connector must retry the failed write and re-resolve the
-        // promoted master through Sentinel
-        expect($this->reissueUntilSuccess(fn () => $connection->set('chaos_stale', 'v2')))->toBeTrue()
+        // promoted master through Sentinel. Its proxy listener was freshly recreated by
+        // beforeEach resetAll (and by the previous test's re-enable), and CI host port
+        // forwarding can refuse connects for seconds - re-verify traffic and widen the
+        // retry window, or the reconnect-in-onFail exception exhausts the reissue budget
+        $this->waitForProxyReady($newAddress['port'], 10);
+
+        expect($this->reissueUntilSuccess(fn () => $connection->set('chaos_stale', 'v2'), attempts: 20))->toBeTrue()
             ->and($connection->get('chaos_stale'))->toBe('v2');
 
         $cached = app(NodeAddressCache::class)->get($service);


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of \`FailoverTest > stale master connection retries and lands on the promoted master\` seen in CI (failed on the #46 merge run and on the #67/#68 runs; passed on the original #46 PR run).

**Root cause** (from the CI stack trace + the suite's own documented failure modes):
1. \`beforeEach\` \`resetAll()\` recreates every toxiproxy listener, and each test can re-enable proxies; the suite already documents that freshly (re)created listeners "can be refused through the host port forwarding" (\`sentinelConnectionWithRetry\`, \`waitForProxyReady\` exist for this)
2. When the failover promotes a node whose proxy listener was freshly recreated, the package's \`retry()\` \`onFail\` reconnect resolves the promoted master through Sentinel and connects through that fresh listener — the refused connect throws out of \`onFail\` (\`Retryable.php:77\`) and aborts the command retry loop
3. \`reissueUntilSuccess\`'s default budget (5 × 500ms ≈ 2.5s) is too short for cold CI runners, so the raw \`RedisException: Connection refused\` surfaces and the test fails

**Fix (test-only, no product changes):**
- Re-verify proxy traffic with \`waitForProxyReady($newAddress['port'], 10)\` right after \`waitForMasterChange()\` in both tests that reissue writes after a failover
- Widen \`reissueUntilSuccess\` to \`attempts: 20\` (~10s budget) for those writes

## Verification

- Chaos suite green twice locally (9 passed, 58.6s/59.2s), lint passing
- Root cause corroborated by 3 CI runs: failed on the #46 merge-commit run and on the PR #67/#68 chaos jobs (which contain no toxiproxy test changes), passed on the original #46 PR run — classic cold-runner flake, not related to those PRs' changes

## Note

Merging this should also unblock PRs #67 and #68, whose chaos jobs fail on the same flake.