### PR TITLE
fix: default read_timeout to 60s to prevent indefinite hangs on half-open sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,8 +664,8 @@ your own Redis topology, workload, and deployment model.
 - **Scan-family commands reset their cursor** on retry after a reconnection, so iteration restarts on the new node (SCAN
   semantics allow duplicates).
 - **`read_timeout` defaults to 60 seconds** (both the Redis client and the Sentinel client): a blocking command on a half-open
-  socket now fails after 60s instead of hanging the worker forever. Set an explicit `read_timeout` if you need unbounded
-  blocking reads, and keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
+  socket now fails after 60s instead of hanging the worker forever. Set `read_timeout: 0` for unbounded blocking reads, and
+  always keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
 - **`flushdb($async)` / `flushall($sync)` flags are not reliably forwarded**: on phpredis 6.x the flag is ignored (commands
   run synchronously); on older 5.x releases a truthy argument may be sent as `ASYNC`. Do not rely on the parameter for
   predictable background flushing.

--- a/README.md
+++ b/README.md
@@ -663,8 +663,9 @@ your own Redis topology, workload, and deployment model.
   is re-executed after reconnection. Only use idempotent operations inside, or handle duplicates in your callback.
 - **Scan-family commands reset their cursor** on retry after a reconnection, so iteration restarts on the new node (SCAN
   semantics allow duplicates).
-- **`read_timeout` defaults to 0** (no timeout, like Laravel's PhpRedis driver): blocking commands can hang indefinitely if the
-  server disappears without closing the socket. Set an explicit `read_timeout` for latency-sensitive paths.
+- **`read_timeout` defaults to 60 seconds** (both the Redis client and the Sentinel client): a blocking command on a half-open
+  socket now fails after 60s instead of hanging the worker forever. Set an explicit `read_timeout` if you need unbounded
+  blocking reads, and keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
 - **`flushdb($async)` / `flushall($sync)` flags are not reliably forwarded**: on phpredis 6.x the flag is ignored (commands
   run synchronously); on older 5.x releases a truthy argument may be sent as `ASYNC`. Do not rely on the parameter for
   predictable background flushing.

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -131,7 +131,7 @@ class RedisSentinelConnector extends PhpRedisConnector
                 'port' => $port,
                 'password' => Arr::get($config, 'password', ''),
                 'timeout' => Arr::get($config, 'timeout', 5.0),
-                'read_timeout' => Arr::get($config, 'read_timeout', 0),
+                'read_timeout' => Arr::get($config, 'read_timeout', 60.0),
                 'retry_interval' => Arr::get($config, 'retry_interval') ?? Arr::get($config, 'sentinel.retry_interval', 0),
                 'persistent' => Arr::get($config, 'persistent') ?? Arr::get($config, 'sentinel.persistent', 0),
                 'database' => Arr::get($config, 'database') ?? Arr::get($config, 'sentinel.database', 0),

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -264,7 +264,7 @@ class RedisSentinelConnector extends PhpRedisConnector
                 'connectTimeout' => $config['sentinel']['timeout'] ?? $config['timeout'] ?? 1.0,
                 'persistent' => $config['sentinel']['persistent'] ?? $config['persistent'] ?? null,
                 'retryInterval' => $config['sentinel']['retry_interval'] ?? $config['retry_interval'] ?? 0,
-                'readTimeout' => $config['sentinel']['read_timeout'] ?? $config['read_timeout'] ?? 0,
+                'readTimeout' => $config['sentinel']['read_timeout'] ?? $config['read_timeout'] ?? 60.0,
             ];
 
             if (($password = $config['sentinel']['password'] ?? $config['password'] ?? '') !== '') {

--- a/tests/Unit/Connectors/RedisSentinelConnectorTest.php
+++ b/tests/Unit/Connectors/RedisSentinelConnectorTest.php
@@ -222,3 +222,38 @@ test('the data client timeout is not coupled to the sentinel timeout', function 
 
     expect($connector->captured[1]['timeout'])->toBe(2.5);
 });
+
+test('createClient defaults read_timeout to 60 when config omits it', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        protected function getMasterAddress(array $config, bool $refresh = false): array
+        {
+            return ['ip' => CONNECTOR_TEST_HOST, 'port' => (int) env('REDIS_STANDALONE_PORT', 6379)];
+        }
+    };
+
+    $client = (new ReflectionMethod($connector, 'createClient'))->invoke($connector, [
+        'sentinel' => ['service' => 'master', 'host' => CONNECTOR_TEST_HOST],
+        'password' => env('REDIS_PASSWORD', 'test'),
+    ]);
+
+    expect((float) $client->getOption(Redis::OPT_READ_TIMEOUT))->toBe(60.0);
+});
+
+test('createClient preserves explicit read_timeout override', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        protected function getMasterAddress(array $config, bool $refresh = false): array
+        {
+            return ['ip' => CONNECTOR_TEST_HOST, 'port' => (int) env('REDIS_STANDALONE_PORT', 6379)];
+        }
+    };
+
+    $client = (new ReflectionMethod($connector, 'createClient'))->invoke($connector, [
+        'sentinel' => ['service' => 'master', 'host' => CONNECTOR_TEST_HOST],
+        'password' => env('REDIS_PASSWORD', 'test'),
+        'read_timeout' => 5,
+    ]);
+
+    expect((float) $client->getOption(Redis::OPT_READ_TIMEOUT))->toBe(5.0);
+});

--- a/tests/Unit/Connectors/RedisSentinelConnectorTest.php
+++ b/tests/Unit/Connectors/RedisSentinelConnectorTest.php
@@ -257,3 +257,30 @@ test('createClient preserves explicit read_timeout override', function () {
 
     expect((float) $client->getOption(Redis::OPT_READ_TIMEOUT))->toBe(5.0);
 });
+
+test('createSentinel defaults Sentinel client readTimeout to 60', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public ?array $capturedOptions = null;
+
+        protected function createSentinelInstance(array $options): RedisSentinel
+        {
+            $this->capturedOptions = $options;
+
+            return parent::createSentinelInstance($options);
+        }
+    };
+
+    config(['database.redis.my-sentinel' => [
+        'sentinel' => [
+            'host' => CONNECTOR_TEST_HOST,
+            'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+            'service' => 'master',
+            'password' => env('REDIS_PASSWORD', 'test'),
+        ],
+    ]]);
+
+    $connector->createSentinel('my-sentinel');
+
+    expect($connector->capturedOptions['readTimeout'])->toBe(60.0);
+});


### PR DESCRIPTION
## Summary
- Closes #51
- `read_timeout` defaults to **60s** instead of `0` (no timeout) on the Redis data client (`RedisSentinelConnector::createClient()`) — a blocking command on a half-open TCP socket (network partition without FIN/RST) now fails after 60s instead of hanging the worker forever with no exception, leaving the retry layer inert and `horizon:alive` stuck.
- Same default applied to the **Sentinel client itself** (`createSentinel()`, `readTimeout`) — slightly beyond the issue's literal surgical fix: a `ping()` against a half-open Sentinel node would otherwise block the fallback loop forever (same root cause). Revertible in one line if strict issue scope is preferred.
- README updated: documents the 60s default for both clients and that `read_timeout: 0` still means unbounded (escape hatch, kept above your longest blocking command).

## Notes
- Aligned with Laravel's documented `REDIS_READ_TIMEOUT` default. Explicit per-connection overrides unchanged (existing test asserts `read_timeout => 5` still passes through).
- Out of scope per issue: connect timeout changes, subscribe/BLPOP exemptions.
- Follow-up material (deferred): a Sentinel-specific readTimeout default (5–10s) would fail over faster than 60s×N in the worst case; phpredis <6 positional-ctor hardening.

## Testing
- 3 new integration tests (no mocks, live Sentinel cluster): default = 60.0 on data client, explicit override preserved, Sentinel client default = 60.0.
- Full suite: 499 passed / 2706 assertions (incl. toxiproxy chaos group). `composer lint` (Pint) clean.
- TDD: tests written first, verified failing (0 vs 60.0), then fixed.