### PR TITLE
fix: exclude replicas with a disconnected master link from read routing

### DIFF
--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -212,7 +212,8 @@ class RedisSentinelConnector extends PhpRedisConnector
 
                 return ! str_contains($flags, 's_down') &&
                        ! str_contains($flags, 'o_down') &&
-                       ! str_contains($flags, 'disconnected');
+                       ! str_contains($flags, 'disconnected') &&
+                       ($s['master-link-status'] ?? 'ok') !== 'disconnect';
             }));
 
             if (empty($replicas)) {

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -391,6 +391,92 @@ test('it filters out unhealthy replicas', function () {
     expect($connection->getReadClient()->getHost())->toBe(HOST_3);
 });
 
+test('it filters out replicas with a disconnected master link', function () {
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
+        ['ip' => HOST_3, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'ok'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_3);
+});
+
+test('it falls back to master when all replicas have a disconnected master link', function () {
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
+        ['ip' => HOST_3, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1);
+});
+
 test('it keeps cached master address when refreshing replicas', function () {
     $sentinelMock = Mockery::mock(RedisSentinel::class);
     $sentinelMock->shouldReceive('ping')->andReturn(true);


### PR DESCRIPTION
## Summary
- Closes #53
- The healthy-replica filter now also rejects replicas whose Sentinel `master-link-status` is `disconnect`: such a replica is up but its replication link is broken, so it serves a **frozen dataset** while passing the previous `flags`-only filter (`s_down`/`o_down`/`disconnected`).
- Empty-filter fallback to master keeps working: if every replica has a disconnected link, reads fall back to the master.

## Testing
- 2 new integration tests in `ReadWriteSplittingTest` (Mockery Sentinel, no live Redis needed): mixed health → healthy replica chosen; all links disconnected → master fallback.
- Deterministic post-fix (random pick has a single survivor); pre-fix the mixed-health test fails by construction.
- Full suite: 498 passed / 2705 assertions, `composer lint` clean.

## Deferred (follow-up material)
- Anonymous connector test harness is now copy-pasted 5× in `ReadWriteSplittingTest` — extract a shared helper on next touch of that file.