### PR TITLE
fix: default node_cache.ttl to 15s so long-lived workers detect failovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ return [
 - Resolved master/replica addresses are cached with a TTL: `phpredis-sentinel.node_cache.ttl` (seconds, default `15`; `0`
   disables expiry — discouraged, it delays failover detection in long-lived workers).
 
+> If you previously published the config file, your copy still defaults to `env('REDIS_SENTINEL_NODE_CACHE_TTL', 0)` — set the env var or update your copy to get the new 15 s default.
+
 > If you previously published the config file, add `'No reachable Redis Sentinel host found'` to `retry.sentinel.messages` to retry total Sentinel outages.
 
 ### Laravel Redis Binding Override

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ return [
 - `timeout` for the data connection defaults to **5 seconds** and is no longer derived from `sentinel.timeout`.
 - The data client uses strictly `password`; `sentinel.password` only authenticates against Sentinel nodes.
 - `retry.redis.messages` can be overridden **per connection** (`retry.redis.messages` inside the connection config), like `attempts`/`delay`.
-- Resolved master/replica addresses can be cached with a TTL: `phpredis-sentinel.node_cache.ttl` (seconds, `0` = disabled).
+- Resolved master/replica addresses are cached with a TTL: `phpredis-sentinel.node_cache.ttl` (seconds, default `15`; `0`
+  disables expiry — discouraged, it delays failover detection in long-lived workers).
 
 > If you previously published the config file, add `'No reachable Redis Sentinel host found'` to `retry.sentinel.messages` to retry total Sentinel outages.
 

--- a/config/phpredis-sentinel.php
+++ b/config/phpredis-sentinel.php
@@ -5,8 +5,8 @@ return [
 
     'node_cache' => [
         // Seconds a resolved master/replica address may stay cached in this process.
-        // 0 disables expiry (legacy behaviour). Stale entries delay failover detection.
-        'ttl' => env('REDIS_SENTINEL_NODE_CACHE_TTL', 0),
+        // 0 disables expiry (discouraged: stale topology delays failover detection in long-lived workers).
+        'ttl' => env('REDIS_SENTINEL_NODE_CACHE_TTL', 15),
     ],
 
     'log' => [

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -101,7 +101,8 @@ class RedisSentinelServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(NodeAddressCache::class, fn ($app) => new NodeAddressCache(
-            (float) $app['config']->get('phpredis-sentinel.node_cache.ttl', 0)
+            // Null counts as missing (Laravel 13 offsetUnset sets null instead of removing the key).
+            (float) ($app['config']->get('phpredis-sentinel.node_cache.ttl') ?? 15)
         ));
         $this->app->bind('redis.sentinel', RedisSentinelConnector::class);
     }

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -101,7 +101,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(NodeAddressCache::class, fn ($app) => new NodeAddressCache(
-            // Null counts as missing (Laravel 13 offsetUnset sets null instead of removing the key).
+            // Null counts as missing (Laravel 10+ offsetUnset sets null instead of removing the key).
             (float) ($app['config']->get('phpredis-sentinel.node_cache.ttl') ?? 15)
         ));
         $this->app->bind('redis.sentinel', RedisSentinelConnector::class);

--- a/tests/Feature/Orchestra/NodeCacheDefaultTtlTest.php
+++ b/tests/Feature/Orchestra/NodeCacheDefaultTtlTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+
+test('node_cache.ttl defaults to 15 seconds', function () {
+    expect(config('phpredis-sentinel.node_cache.ttl'))->toBe(15);
+});
+
+test('node cache falls back to a 15s ttl when the config key is missing', function () {
+    config()->offsetUnset('phpredis-sentinel.node_cache.ttl');
+    app()->forgetInstance(NodeAddressCache::class);
+
+    $cache = app(NodeAddressCache::class);
+
+    $ttl = new ReflectionProperty(NodeAddressCache::class, 'ttlSeconds');
+
+    expect($ttl->getValue($cache))->toBe(15.0);
+});


### PR DESCRIPTION
## Summary
- Closes #52
- `node_cache.ttl` defaulted to `0` (entries never expire): after a failover, a long-lived read-mostly worker kept resolving the **demoted master** indefinitely — the read path never self-heals (unlike writes, which fail with READONLY and refresh).
- Default is now **15 seconds** (config default + container fallback, via `?? 15` — required because `Repository::offsetUnset` sets the key to `null` on Laravel 10+, identical across the supported matrix).
- Explicit `0` still disables expiry (backwards-compatible escape hatch); README documents the new default, discourages `0`, and notes that previously **published configs keep the old `env(..., 0)` fallback** and must be updated to benefit.

## Testing
- 2 new tests: config default = 15 via mergeConfigFrom; container fallback = 15s when the config key is missing/null.
- Full suite: 498 passed / 2705 assertions (incl. toxiproxy chaos group), `composer lint` clean. The existing `ttl zero keeps entries forever` test is untouched and green.

## Deferred (follow-up material)
- Consider `feat:` instead of `fix:` if a minor bump is preferred to signal the default change (maintainer's call — kept `fix:` per the issue framing).