### PR TITLE
refactor: extract shared stickiness reset handler; document Octane coroutine limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ required.
 - ✅ Configurable retry logic for both Sentinel and Redis connections
 - ✅ Full support for Laravel Cache, Queue, Session, Broadcasting
 - ✅ Native Laravel Horizon integration
-- ✅ Laravel Octane compatible (Swoole and RoadRunner runtimes)
+- ✅ Laravel Octane compatible (sequential runtimes — see [Laravel Octane Support](#laravel-octane-support) for coroutine limits)
 
 ### Advanced Features
 
@@ -479,6 +479,19 @@ The package is compatible with Laravel Octane and supports long-lived processes:
 // ✅ Graceful reconnection on failures
 ```
 
+### Coroutine runtimes (Swoole) and R/W splitting
+
+The connection mutates shared per-command state (master/replica client swap, sticky flag), so **concurrent
+coroutines sharing one worker are not fully supported for R/W splitting**: interleaving can flip routing
+mid-request, and the retry backoff blocks the whole worker, not just the coroutine that hit the failure.
+
+- **Safe**: sequential runtimes — FPM, FrankenPHP worker mode, RoadRunner, Swoole with a single in-flight
+  request per worker.
+- **Not safe**: Swoole coroutines sharing one connection concurrently (e.g. async requests in the same worker).
+
+If you rely on concurrent coroutines, disable `read_only_replicas` (everything routes to the master, no client
+swap) or keep R/W splitting on sequential workers.
+
 ### No Configuration Needed
 
 Simply use Octane as normal:
@@ -489,7 +502,8 @@ php artisan octane:start --server=swoole
 php artisan octane:start --server=roadrunner
 ```
 
-The package listens to Octane's `RequestReceived` event and resets state automatically.
+The package listens to Octane's lifecycle events (`RequestReceived`, `TaskReceived`, `TickReceived`,
+`OperationTerminated`) and to queue `JobProcessing`, and resets stickiness automatically at each boundary.
 
 ## Horizon Integration
 

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -54,21 +54,25 @@ class RedisSentinelServiceProvider extends ServiceProvider
             return;
         }
 
-        $resetCallback = function () {
-            $app = Facade::getFacadeApplication() ?: Container::getInstance();
-            if ($app->bound(RedisSentinelManager::class)) {
-                $manager = $app->make(RedisSentinelManager::class);
-
-                foreach ($manager->connections() as $connection) {
-                    if ($connection instanceof RedisSentinelConnection) {
-                        $connection->resetStickiness();
-                    }
-                }
-            }
-        };
+        $resetCallback = fn () => $this->resetAllStickiness();
 
         foreach (['RequestReceived', 'TickReceived', 'TaskReceived', 'OperationTerminated'] as $event) {
             $this->app['events']->listen("Laravel\\Octane\\Events\\{$event}", $resetCallback);
+        }
+    }
+
+    private function resetAllStickiness(): void
+    {
+        $app = Facade::getFacadeApplication() ?: Container::getInstance();
+
+        if (! $app->bound(RedisSentinelManager::class)) {
+            return;
+        }
+
+        foreach ($app->make(RedisSentinelManager::class)->connections() as $connection) {
+            if ($connection instanceof RedisSentinelConnection) {
+                $connection->resetStickiness();
+            }
         }
     }
 
@@ -236,13 +240,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
                 return;
             }
 
-            $manager = $this->app->make(RedisSentinelManager::class);
-
-            foreach ($manager->connections() as $connection) {
-                if ($connection instanceof RedisSentinelConnection) {
-                    $connection->resetStickiness();
-                }
-            }
+            $this->resetAllStickiness();
         });
     }
 

--- a/tests/Feature/OctaneCompatibilityTest.php
+++ b/tests/Feature/OctaneCompatibilityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Goopil\LaravelRedisSentinel\RedisSentinelServiceProvider;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -70,4 +71,37 @@ test('bootOctane listens to all Octane lifecycle events', function () {
     foreach ($expectedEvents as $event) {
         expect($listenedEvents)->toContain($event);
     }
+});
+
+test('octane lifecycle callback resets stickiness on all sentinel connections', function () {
+    $masterClient = Mockery::mock(Redis::class);
+    $replicaClient = Mockery::mock(Redis::class);
+    $connection = new RedisSentinelConnection($masterClient, fn () => $masterClient, [], fn () => $replicaClient);
+
+    $masterClient->expects('set')->once()->andReturn(true);
+    $connection->set('foo', 'bar');
+
+    $manager = app(RedisSentinelManager::class);
+    $connectionsProp = new ReflectionProperty(RedisSentinelManager::class, 'connections');
+    $connectionsProp->setAccessible(true);
+    $connectionsProp->setValue($manager, ['phpredis-sentinel' => $connection]);
+
+    $captured = [];
+    $events = Mockery::mock(Dispatcher::class);
+    $events->shouldReceive('listen')->andReturnUsing(function ($event, $callback) use (&$captured) {
+        $captured[$event] = $callback;
+    });
+
+    app()->instance('octane', new stdClass);
+    app()->instance('events', $events);
+
+    $provider = new RedisSentinelServiceProvider(app());
+    $method = new ReflectionMethod($provider, 'bootOctane');
+    $method->invoke($provider);
+
+    ($captured['Laravel\Octane\Events\TaskReceived'])();
+
+    $wroteProp = (new ReflectionClass($connection))->getProperty('wroteToMaster');
+
+    expect($wroteProp->getValue($connection))->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- Closes #57
- Extracts the duplicated stickiness-reset handler (identical closure bodies in `bootOctane()` and `bootQueueEvents()`) into one private `resetAllStickiness()` method — behavior-preserving, per-call-site guards stacked (queue keeps its `resolved()` early-return).
- README Octane section: states that **concurrent-coroutine runtimes (Swoole) are not fully supported for R/W splitting** (per-command client swap + sticky flag are shared mutable state; backoff blocks the whole worker), lists safe sequential runtimes (FPM, FrankenPHP worker mode, RoadRunner), and documents the mitigation (disable `read_only_replicas`). Feature bullet and stale "listens to RequestReceived" sentence fixed; full lifecycle event list documented.

## Note on scope and release impact
- The listeners for `TaskReceived`/`TickReceived`/`OperationTerminated` were **already shipped in 1.5.0** (commit 99352f2) — this branch completes the issue's remaining items (dedup + docs). `refactor:` + `docs:` commits intentionally do not trigger a semantic-release version (the user-facing fix is already published); `Closes #57` still closes the issue on merge.
- New test pins the behavior end-to-end: captured Octane `TaskReceived` callback resets stickiness on all `RedisSentinelConnection` instances (Mockery, no live Redis).

## Testing
- Full suite: 497 passed / 2705 assertions, `composer lint` clean. Octane test files all green.