### PR TITLE
fix: fail fast when all sentinels are unreachable (~30s stall per command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ The package uses **exponential backoff with jitter** to avoid thundering herd:
 - Third retry: ~4s
 - And so on...
 
+When every Sentinel node is unreachable, resolution attempts are circuit-broken: after 2 consecutive failed
+resolutions, further attempts fail immediately (rethrowing the last resolution error) for 5 seconds, instead of
+paying the full retry/backoff cost (~30s) on every command. A successful resolution or the cooldown expiry resets
+the breaker. The command that opens the breaker still completes its own retry cycle, so expect the first failing
+command to take up to ~30s; the following ones fail fast until the breaker re-opens a resolution window.
+
 ## Read/Write Splitting
 
 When `read_only_replicas` is enabled, the package provides intelligent command routing:

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -34,6 +34,16 @@ class RedisSentinelConnector extends PhpRedisConnector
 
     protected ?string $phpredisVersion = null;
 
+    private const BREAKER_THRESHOLD = 2;
+
+    private const BREAKER_COOLDOWN_SECONDS = 5.0;
+
+    private static int $resolutionFailures = 0;
+
+    private static ?float $breakerOpenedAt = null;
+
+    private static ?Throwable $breakerLastException = null;
+
     public function __construct(NodeAddressCache $masterCache, ConfigRepository $config)
     {
         $this->masterCache = $masterCache;
@@ -99,8 +109,24 @@ class RedisSentinelConnector extends PhpRedisConnector
             throw new ConfigurationException(sprintf("No service name has been specified for the Redis Sentinel connection '%s'.", $name));
         }
 
+        $this->guardSentinelResolution();
+
         return $this->retryOnFailure(
-            fn () => $this->connectToSentinel($config),
+            function () use ($config) {
+                $this->guardSentinelResolution();
+
+                try {
+                    $instance = $this->connectToSentinel($config);
+                } catch (Throwable $e) {
+                    $this->recordSentinelFailure($e);
+
+                    throw $e;
+                }
+
+                $this->recordSentinelSuccess();
+
+                return $instance;
+            },
             onFail: $this->onSentinelFail($service, 'connectToSentinel'),
             onReconnect: $this->onSentinelReconnect($service, 'connectToSentinel'),
             onMaxFail: $this->onSentinelMaxFail($service, 'connectToSentinel')
@@ -158,13 +184,25 @@ class RedisSentinelConnector extends PhpRedisConnector
             return $master;
         }
 
+        $this->guardSentinelResolution();
+
         ['ip' => $ip, 'port' => $port] = $this->retryOnFailure(
             function () use ($config, $service) {
-                if ($master = $this->connectToSentinel($config)->master($service)) {
-                    return $master;
-                }
+                $this->guardSentinelResolution();
 
-                throw new RedisException(sprintf("No master found for service '%s'.", $service));
+                try {
+                    if ($master = $this->connectToSentinel($config)->master($service)) {
+                        $this->recordSentinelSuccess();
+
+                        return $master;
+                    }
+
+                    throw new RedisException(sprintf("No master found for service '%s'.", $service));
+                } catch (Throwable $e) {
+                    $this->recordSentinelFailure($e);
+
+                    throw $e;
+                }
             },
             onFail: $this->onSentinelFail($service, 'getMasterAddress'),
             onReconnect: $this->onSentinelReconnect($service, 'getMasterAddress'),
@@ -192,14 +230,27 @@ class RedisSentinelConnector extends PhpRedisConnector
         $replicas = $this->masterCache->getReplicas($service);
 
         if (empty($replicas)) {
+            $this->guardSentinelResolution();
+
             $slaves = $this->retryOnFailure(
                 function () use ($config, $service) {
-                    $result = $this->connectToSentinel($config)->slaves($service);
-                    if ($result === false) {
-                        throw new RedisException(sprintf("No replicas found for service '%s'.", $service));
-                    }
+                    $this->guardSentinelResolution();
 
-                    return $result;
+                    try {
+                        $result = $this->connectToSentinel($config)->slaves($service);
+
+                        if ($result === false) {
+                            throw new RedisException(sprintf("No replicas found for service '%s'.", $service));
+                        }
+
+                        $this->recordSentinelSuccess();
+
+                        return $result;
+                    } catch (Throwable $e) {
+                        $this->recordSentinelFailure($e);
+
+                        throw $e;
+                    }
                 },
                 onFail: $this->onSentinelFail($service, 'getReplicaAddress'),
                 onReconnect: $this->onSentinelReconnect($service, 'getReplicaAddress'),
@@ -294,6 +345,46 @@ class RedisSentinelConnector extends PhpRedisConnector
             0,
             $lastException
         );
+    }
+
+    private function guardSentinelResolution(): void
+    {
+        if (self::$breakerOpenedAt === null) {
+            return;
+        }
+
+        if ((microtime(true) - self::$breakerOpenedAt) >= self::BREAKER_COOLDOWN_SECONDS) {
+            self::$breakerOpenedAt = null;
+            self::$resolutionFailures = 0;
+            self::$breakerLastException = null;
+
+            return;
+        }
+
+        throw self::$breakerLastException;
+    }
+
+    private function recordSentinelFailure(Throwable $exception): void
+    {
+        // Only Sentinel unreachability (connectToSentinel exhausting all hosts) opens the breaker;
+        // a reachable Sentinel that has no master/replicas for the service is not a Sentinel outage.
+        if (! $exception instanceof ConfigurationException) {
+            return;
+        }
+
+        self::$resolutionFailures++;
+        self::$breakerLastException = $exception;
+
+        if (self::$resolutionFailures >= self::BREAKER_THRESHOLD) {
+            self::$breakerOpenedAt = microtime(true);
+        }
+    }
+
+    private function recordSentinelSuccess(): void
+    {
+        self::$resolutionFailures = 0;
+        self::$breakerOpenedAt = null;
+        self::$breakerLastException = null;
     }
 
     protected function getService(array $config): ?string

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,9 +3,11 @@
 namespace Goopil\LaravelRedisSentinel\Tests;
 
 use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
 use Goopil\LaravelRedisSentinel\RedisSentinelServiceProvider;
 use Illuminate\Contracts\Config\Repository;
 use Orchestra\Testbench\TestCase as Orchestra;
+use ReflectionProperty;
 
 class TestCase extends Orchestra
 {
@@ -21,6 +23,13 @@ class TestCase extends Orchestra
         // Flush the master address cache between tests
         if ($app->bound(NodeAddressCache::class)) {
             $app->make(NodeAddressCache::class)->flush();
+        }
+
+        // Reset the Sentinel resolution breaker between tests (static connector state)
+        foreach (['resolutionFailures' => 0, 'breakerOpenedAt' => null, 'breakerLastException' => null] as $property => $value) {
+            $reflection = new ReflectionProperty(RedisSentinelConnector::class, $property);
+            $reflection->setAccessible(true);
+            $reflection->setValue(null, $value);
         }
 
         // Load workbench routes

--- a/tests/Unit/Connectors/SentinelBreakerTest.php
+++ b/tests/Unit/Connectors/SentinelBreakerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
+
+const BREAKER_TEST_HOST = '127.0.0.1';
+
+function breakerConnector(int &$calls, int $failuresBeforeSuccess = PHP_INT_MAX): RedisSentinelConnector
+{
+    // failuresBeforeSuccess defaults to PHP_INT_MAX so the connector never succeeds (all Sentinels unreachable);
+    // a positive value fails that many resolutions before returning a working Sentinel.
+    return new class($calls, $failuresBeforeSuccess) extends RedisSentinelConnector
+    {
+        public function __construct(public int &$calls, public int $failuresBeforeSuccess)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        public function getMasterAddress(array $config, bool $refresh = false): array
+        {
+            return parent::getMasterAddress($config, $refresh);
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            $this->calls++;
+
+            if ($this->calls > $this->failuresBeforeSuccess) {
+                $sentinel = Mockery::mock(RedisSentinel::class);
+                $sentinel->shouldReceive('master')->andReturn(['ip' => '127.0.0.1', 'port' => 6379]);
+
+                return $sentinel;
+            }
+
+            throw new ConfigurationException('No reachable Redis Sentinel host found.');
+        }
+    };
+}
+
+test('breaker fails fast after threshold failures and records per-attempt count', function () {
+    $calls = 0;
+    $connector = breakerConnector($calls);
+
+    $master = null;
+
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+    } catch (Throwable $e) {
+        $master = $e;
+    }
+
+    expect($master)->toBeInstanceOf(ConfigurationException::class)
+        ->and($calls)->toBe(2);
+
+    $start = microtime(true);
+
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+    } catch (Throwable $e) {
+        $master = $e;
+    }
+
+    expect($master)->toBeInstanceOf(ConfigurationException::class)
+        ->and($calls)->toBe(2)
+        ->and((microtime(true) - $start) * 1000)->toBeLessThan(50.0);
+});
+
+test('breaker closes after the cooldown and a full resolution cycle runs again', function () {
+    $calls = 0;
+    $connector = breakerConnector($calls);
+
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+    } catch (Throwable) {
+    }
+
+    expect($calls)->toBe(2);
+
+    $openedAt = new ReflectionProperty(RedisSentinelConnector::class, 'breakerOpenedAt');
+    $openedAt->setAccessible(true);
+    $openedAt->setValue(null, microtime(true) - 10.0);
+
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+    } catch (Throwable) {
+    }
+
+    expect($calls)->toBe(4);
+});
+
+test('a successful resolution resets the breaker counter', function () {
+    $calls = 0;
+    $connector = breakerConnector($calls, 1);
+
+    $master = $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+
+    expect($master)->toBeArray()
+        ->and($calls)->toBe(2);
+
+    $failures = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionFailures');
+    $failures->setAccessible(true);
+
+    expect($failures->getValue())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- Closes #56
- Per-process open/closed circuit breaker around **Sentinel resolution**: after 2 consecutive failed resolution attempts, further attempts fail immediately for 5 seconds — rethrowing the **last resolution exception** (no new exception type, so existing error handling is unaffected) — instead of every command paying the full retry/backoff cost (~26-30s).
- Placement: the guard runs at the 3 resolution entry points **after cache-hit checks** (a valid `node_cache` entry still serves reads during a Sentinel outage) and inside the resolution closures so intra-cycle attempts short-circuit their network work. The command that **opens** the breaker still completes its own (now cheap) retry cycle — inherent to the no-new-exception constraint.
- Only `ConfigurationException` (Sentinel unreachable) counts toward the threshold — a reachable Sentinel with a missing service ("No master found") does not, matching the outage semantics and keeping existing retry tests intact. Success resets the breaker; cooldown expiry closes it (no half-open probing, per issue scope).
- README "Retry Strategy" section documents the new failure timing.

## Testing
- 3 new unit tests (`SentinelBreakerTest`, no live Redis needed): fast-fail after threshold with attempt-count pinning (exactly 2 network attempts) + < 50 ms open-window assertion; cooldown expiry → full cycle again; success resets the counter.
- Full suite: **507 passed / 2722 assertions, 0 failed, 0 skipped** (toxiproxy chaos group included — the breaker stays closed on data-node cuts, only Sentinel unreachability triggers it). `composer lint` clean.

## Notes / deferred
- Manual real-outage check (`docker compose stop redis-sentinel`) left for post-merge: the chaos overlay only proxies data nodes, so there is no automated sentinel-unreachable scenario (follow-up: add a sentinel proxy to `docker-compose.chaos.yml`).
- Fast-fails dispatched from the outer guard emit no package event/log (in-loop attempts still do) — minor observability gap, one-line follow-up in `guardSentinelResolution()`.
- The breaker-triggering command still burns its backoff ladder (~30s worst case): accepted per issue constraint (exception type must not change).