### PR TITLE
fix: unquote horizon:pre-stop start-command default and return 1 on kill failure

### DIFF
--- a/src/Commands/HorizonWorkerPreStop.php
+++ b/src/Commands/HorizonWorkerPreStop.php
@@ -23,11 +23,11 @@ class HorizonWorkerPreStop extends Command
      *
      * @var string
      */
-    protected $signature = "horizon:pre-stop
+    protected $signature = 'horizon:pre-stop
                             {--wait : Wait for all workers to terminate}
-                            {--start-command='php artisan horizon'}
+                            {--start-command=}
                             {--timeout=60}
-                            ";
+                            ';
 
     /**
      * The console command description.
@@ -54,7 +54,7 @@ class HorizonWorkerPreStop extends Command
             );
         }
 
-        $startCommand = $this->option('start-command');
+        $startCommand = $this->option('start-command') ?: 'php artisan horizon';
 
         $pid = collect($masters->all())
             ->filter(fn ($master) => str_starts_with($master->name, gethostname().':'))
@@ -100,6 +100,8 @@ class HorizonWorkerPreStop extends Command
                     pid: $pid,
                     reason: $error,
                 ));
+
+                return 1;
             } else {
                 $this->info(
                     sprintf(

--- a/tests/Feature/Horizon/Commands/HorizonWorkerPreStopTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerPreStopTest.php
@@ -105,10 +105,10 @@ test('horizon:pre-stop kills the first pid from multi-line pgrep output', functi
     $status = Artisan::call('horizon:pre-stop', ['--start-command' => 'anything']);
 
     // 999999999 does not exist: the TERM fails and the failure is reported,
-    // but the first numeric line of the multi-line pgrep output was targeted.
+    // the hook exits 1 (a failing preStop hook does not block pod termination in K8s).
     expect($command->signalledPids)->toContain(999999999)
         ->and($command->signalledPids)->not->toContain(67890)
-        ->and($status)->toBe(0);
+        ->and($status)->toBe(1);
 });
 
 test('horizon:pre-stop builds pgrep process safely', function () {
@@ -127,4 +127,39 @@ test('horizon:pre-stop builds pgrep process safely', function () {
         ->and($commandLine)->toContain('-f')
         ->and($commandLine)->not->toContain('-x')
         ->and($commandLine)->toContain("'php artisan horizon; rm -rf /'");
+});
+
+test('horizon:pre-stop falls back to the unquoted default start command', function () {
+    $repository = Mockery::mock(MasterSupervisorRepository::class);
+    $repository->expects('all')->andReturn([]);
+    app()->instance(MasterSupervisorRepository::class, $repository);
+
+    $process = Mockery::mock(Process::class);
+    $process->shouldReceive('run')->once();
+    $process->shouldReceive('getOutput')->andReturn('');
+
+    $command = new class($process) extends HorizonWorkerPreStop
+    {
+        public ?string $captured = null;
+
+        public function __construct(private Process $mockedProcess)
+        {
+            parent::__construct();
+        }
+
+        protected function buildPgrepProcess(string $startCommand, int $timeout): Process
+        {
+            $this->captured = $startCommand;
+
+            return $this->mockedProcess;
+        }
+    };
+
+    app()->bind(HorizonWorkerPreStop::class, fn () => $command);
+
+    expect((new HorizonWorkerPreStop)->getDefinition()->getOption('start-command')->getDefault())->toBeNull();
+
+    Artisan::call('horizon:pre-stop');
+
+    expect($command->captured)->toBe('php artisan horizon');
 });

--- a/tests/Feature/Horizon/HorizonCommandEventsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandEventsTest.php
@@ -244,7 +244,7 @@ describe('Horizon Command Events', function () {
 
         $exitCode = Artisan::call('horizon:pre-stop', ['--start-command' => 'php artisan horizon']);
 
-        expect($exitCode)->toBe(0);
+        expect($exitCode)->toBe(1);
 
         Event::assertDispatched(HorizonWorkerTerminateFailed::class, function (HorizonWorkerTerminateFailed $event) {
             return $event->pid === 999999

--- a/tests/Feature/Horizon/HorizonCommandsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandsTest.php
@@ -100,10 +100,9 @@ describe('Horizon Commands', function () {
         });
 
         // Note: posix_kill will fail if PID doesn't exist or no permission.
-        // The command will log an error but might still return 0 if it catches it or just proceed.
-        // Actually it returns 0 at the end of handle().
+        // The command reports the failure and returns 1.
 
         $exitCode = Artisan::call('horizon:pre-stop');
-        expect($exitCode)->toBe(0);
+        expect($exitCode)->toBe(1);
     });
 });


### PR DESCRIPTION
## Summary
- Closes #54
- **Quoted default broke the pgrep fallback**: the signature `{--start-command='php artisan horizon'}` kept the apostrophes (Laravel's parser does not strip them), so the Redis-down fallback ran `pgrep -f "'php artisan horizon'"` and could never match. Now `{--start-command=}` (empty) with a runtime fallback `$this->option('start-command') ?: 'php artisan horizon'` in `handle()`.
- **Kill failure now exits 1**: `posix_kill()` failure returned 0, so the preStop hook "succeeded" while doing nothing. The "not found" path already returned 1. Two existing tests updated accordingly (exit-code expectations only — event/log assertions untouched).

## Behavior changes (intentional)
- **Exit code after a failed kill is now 1** (was 0). K8s `preStop` hooks don't block termination on failure, but monitoring/CI scripts treating exit 0 as success will see the change.
- Edge: explicit `--start-command=` (empty string) now falls back to the default instead of running pgrep with an empty pattern.
- Explicit non-empty `--start-command` values are unaffected.

## Testing
- New regression test: definition default is null; without the option, `buildPgrepProcess` receives exactly `php artisan horizon` (unquoted).
- Updated: multi-line pgrep test now asserts exit 1 on failed TERM; 2 pre-existing tests updated to the new exit code (assertions otherwise unchanged).
- Full suite: 505 passed / 2716 assertions, `composer lint` clean. TDD red→green verified.

## Deferred (cosmetic, from review)
- Redundant `else` after unconditional return (pre-existing style).
- The `'php artisan horizon'` literal stays in `handle()` — extract to a constant only if a second call site appears.