### PR TITLE
feat: surface the no-healthy-replica master fallback with a warning log and event

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ The default retry configuration is intentionally conservative. Tune it according
 
 Monitor and alert on these operational symptoms:
 
+- repeated `RedisSentinelReplicaFallback` events, which mean read/write splitting is disabled and every read lands on the master;
 - repeated `RedisSentinelConnectionFailed` or `RedisSentinelConnectionMaxRetryFailed` events;
 - repeated Sentinel discovery failures;
 - `READONLY` errors after failover, which usually indicate a stale master connection;
@@ -772,6 +773,9 @@ Events\RedisSentinelMasterMaxRetryFailed::class
 Events\RedisSentinelConnectionFailed::class
 Events\RedisSentinelConnectionReconnected::class
 Events\RedisSentinelConnectionMaxRetryFailed::class
+
+// Replica fallback event
+Events\RedisSentinelReplicaFallback::class
 ```
 
 ### Horizon Worker Events

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -9,6 +9,7 @@ use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterMaxRetryFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterReconnected;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelReplicaFallback;
 use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
 use Goopil\LaravelRedisSentinel\Exceptions\NotImplementedException;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
@@ -268,6 +269,9 @@ class RedisSentinelConnector extends PhpRedisConnector
             }));
 
             if (empty($replicas)) {
+                $this->log('No healthy replica, reads fall back to the master', ['service' => $service, 'replicas' => $slaves], 'warning');
+                RedisSentinelReplicaFallback::dispatch($service, $slaves);
+
                 return $this->getMasterAddress($config, $refresh);
             }
 

--- a/src/Events/RedisSentinelReplicaFallback.php
+++ b/src/Events/RedisSentinelReplicaFallback.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+class RedisSentinelReplicaFallback
+{
+    use Dispatchable;
+
+    /**
+     * @param  array<int, array<string, mixed>>  $replicas  The Sentinel-reported replica entries, all unhealthy.
+     */
+    public function __construct(
+        public readonly string $service,
+        public readonly array $replicas = [],
+    ) {}
+}

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -3,6 +3,8 @@
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
 use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelReplicaFallback;
+use Illuminate\Support\Facades\Event;
 
 const HOST_1 = '127.0.0.1';
 const HOST_2 = '127.0.0.2';
@@ -758,4 +760,51 @@ test('it allows custom read-only commands from config', function () {
     );
 
     expect($connection->command('customRead', []))->toBe('result');
+});
+
+test('it dispatches an event when no healthy replica exists and reads fall back to the master', function () {
+    Event::fake([RedisSentinelReplicaFallback::class]);
+
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave,disconnected'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1);
+
+    Event::assertDispatched(RedisSentinelReplicaFallback::class, function (RedisSentinelReplicaFallback $event) {
+        return $event->service === 'mymaster' && count($event->replicas) === 1;
+    });
 });


### PR DESCRIPTION
## Summary
- Closes #48 (option 1 — observability; options 2/3 deliberately deferred)
- When no healthy replica exists, `getReplicaAddress()` silently routed **every read to the master** — exactly when the master is least able to absorb the load (replica outage / post-failover re-establishment window measured at ~10s in the chaos suite). Invisible: no log, no event.
- Now: a **warning log** (service + raw Sentinel replica entries) and a new **`RedisSentinelReplicaFallback`** event (shape mirrors `RedisSentinelMasterFailed`: Dispatchable + readonly promoted props), dispatched unconditionally like all other connector failure events.
- README: new event in the Available Events list + first bullet in "Failure Modes to Monitor" (repeated fallback events = R/W splitting silently disabled).

## Testing
- New integration test (`ReadWriteSplittingTest` harness, Mockery Sentinel): event asserted with service + replica count **and** the read client still lands on the master (BC behavior unchanged).
- Full suite: 509 passed / 2728 assertions, `composer lint` clean.

## Deferred (follow-up material)
- Option 2: configurable `fallback_to_master: bool` (default true) if operators want hard failure instead.
- Option 3: re-query Sentinel once before falling back (post-failover race on a single `slaves()` call).