### PR TITLE
fix: neutralize parent command() retry and reconnect side effects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -187,6 +187,12 @@ parameters:
 			path: src/Connections/RedisSentinelConnection.php
 
 		-
+			message: '#^Property Illuminate\\Redis\\Connections\\PhpRedisConnection\:\:\$connector \(callable\(\)\: mixed\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Connections/RedisSentinelConnection.php
+
+		-
 			message: '#^Strict comparison using \!\=\= between null and Redis will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -297,18 +297,31 @@ class RedisSentinelConnection extends PhpRedisConnection
     public function command($method, array $parameters = []): mixed
     {
         return $this->retry(
-            fn () => parent::command($method, $parameters),
+            function () use ($method, $parameters) {
+                $connector = $this->connector;
+                $this->connector = null;
+
+                try {
+                    return parent::command($method, $parameters);
+                } finally {
+                    $this->connector = $connector;
+                }
+            },
             $method
         );
     }
 
     /**
-     * Laravel 13+ retries read-only commands internally in PhpRedisConnection::command().
-     * Its connector is not Sentinel-aware and it dispatches no events, which would mask
-     * failovers and bypass this connection's retry logic. Disable it entirely so this
-     * connection's retry() wrapper stays the single retry path.
+     * Laravel retries read-only commands internally in PhpRedisConnection::command()
+     * by calling the connector closure with $refresh = false, reconnecting to the
+     * cached (possibly demoted) node without dispatching events; on Laravel 13+ it
+     * also nests retries. Neutralize it entirely so this connection's retry() wrapper
+     * stays the single retry path.
      *
-     * No-op on Laravel 10-12 where the method does not exist on the parent.
+     * No-op on Laravel 10-12, where the parent has no isRetryable() method.
+     *
+     * The connector nulling above also neutralizes the parent's catch-block
+     * reconnect (which passes $refresh = false) on all supported versions.
      *
      * @param  string  $method
      * @param  array<int|string, mixed>  $parameters

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -62,6 +62,8 @@ class RedisSentinelConnector extends PhpRedisConnector
      */
     public function connect(array $config, array $options): RedisSentinelConnection
     {
+        $config = Arr::except($config, 'command_retries');
+
         $connectionConfig = $this->mergeConnectionOptions($config, $options);
         $connector = fn ($refresh = false) => $this->createClient($connectionConfig, $refresh);
 

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -74,6 +74,34 @@ test('a failed sticky read refreshes the master, not the replica', function () {
         ->and($masterRefreshes)->toBe(1);
 });
 
+test('parent command() cannot reconnect or nest retries on Laravel 13', function () {
+    Event::fake();
+
+    $masterClient = Mockery::mock(Redis::class);
+    $masterClient->shouldReceive('get')->times(3)->andThrow(new RedisException('went away'));
+
+    $reconnects = 0;
+    $connection = new RedisSentinelConnection(
+        $masterClient,
+        function () use (&$reconnects, $masterClient) {
+            $reconnects++;
+
+            return $masterClient;
+        },
+        [],
+    );
+
+    $connection->setRetryLimit(2)->setRetryDelay(0)->setRetryMessages(['went away']);
+
+    try {
+        $connection->command('get', ['foo']);
+        $this->fail('RedisException was not thrown.');
+    } catch (RedisException $exception) {
+        expect($exception->getMessage())->toBe('went away')
+            ->and($reconnects)->toBe(3);
+    }
+});
+
 test('a retried scan restarts its cursor on the refreshed client', function () {
     $master1 = Mockery::mock(Redis::class);
     $master2 = Mockery::mock(Redis::class);

--- a/tests/Unit/Connectors/RedisSentinelConnectorTest.php
+++ b/tests/Unit/Connectors/RedisSentinelConnectorTest.php
@@ -258,6 +258,30 @@ test('createClient preserves explicit read_timeout override', function () {
     expect((float) $client->getOption(Redis::OPT_READ_TIMEOUT))->toBe(5.0);
 });
 
+test('connect strips command_retries from the connection config', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        protected function getMasterAddress(array $config, bool $refresh = false): array
+        {
+            return ['ip' => CONNECTOR_TEST_HOST, 'port' => 6379];
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            return Mockery::mock(Redis::class);
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'master', 'host' => CONNECTOR_TEST_HOST],
+        'command_retries' => 3,
+    ], []);
+
+    $config = (new ReflectionProperty(PhpRedisConnection::class, 'config'))->getValue($connection);
+
+    expect($config['command_retries'] ?? null)->toBeNull();
+});
+
 test('createSentinel defaults Sentinel client readTimeout to 60', function () {
     $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
     {


### PR DESCRIPTION
Closes #60

## Summary

Laravel's `PhpRedisConnection::command()` resolves the connection through the `$connector` closure: in its catch block on all supported versions (reconnect with `$refresh = false`), and via a built-in retry loop on Laravel 13+. For this package's connection both paths are harmful:

- the reconnect targets the **cached** node address (possibly a demoted master) and dispatches no events, masking failovers;
- on L13+, the vendor retry nests on top of the package's own `retry()` wrapper, multiplying attempts and bypassing this connection's single-retry-path contract.

This PR neutralizes both for Sentinel-backed connections.

## Changes

**`RedisSentinelConnection::command()`** — the `$connector` closure is captured and nulled around the `parent::command()` call, restored in `finally`. With the closure absent, the parent's catch-block reconnect falls back to identity assignment (safe on every supported version) and the L13+ retry loop cannot re-resolve through the connector. `isRetryable()` returns `false` so the package's `retry()` wrapper remains the single retry path.

**`RedisSentinelConnector::connect()`** — `command_retries` is stripped from the config via `Arr::except` before connection. Laravel 13's semantics for this key would otherwise apply the vendor retry to our connection; the key is now silently ignored, matching the documented package behavior (retries are owned by the package, configured elsewhere).

## Behavior notes

- The effect is broader than Laravel 13: on L10-12 the parent catch-block also called the connector with `$refresh = false` for 'went away'/'socket'/'Connection lost' errors; that wasted, failover-masking reconnect is now neutralized too.
- No path leaves `$this->connector` null: the finally-restore covers success, `RedisException`, `RedisClusterException` and any `Throwable`.
- phpstan: the null assignment triggers a vendor-docblock type error, suppressed via a new baseline entry (repo already baselines vendor-type friction in this file).

## Tests

- `RedisSentinelConnectionRetryTest` — counts client invocations through a forced-failure command: pinned to exactly 3 (`Retryable` limit 2 → limit+1 attempts); red pre-fix (6 invocations with vendor retry active) on every supported Laravel version.
- `RedisSentinelConnectorTest` — via reflection on the (L13-removed `getConfig`) `$config` property, verifies `command_retries` is stripped from the stored config.
- Full suite: 511 passed against the live Sentinel cluster; chaos suite 9/9 with fix.
- `composer run stan` clean (with baseline), Pint clean.

## Deferred

- Nothing. The `command_retries` config key is silently ignored rather than validated-with-error; a hard error could be added if it turns out users rely on it, but the package docs never advertised it.