### PR TITLE
fix: match Horizon master supervisor names by hostname basename with delimiter

### DIFF
--- a/src/Commands/HorizonWorkerPreStop.php
+++ b/src/Commands/HorizonWorkerPreStop.php
@@ -11,6 +11,7 @@ use Illuminate\Cache\CacheManager;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Console\Command;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository as MasterSupervisorRepositoryAlias;
+use Laravel\Horizon\MasterSupervisor;
 use Symfony\Component\Process\Process;
 
 class HorizonWorkerPreStop extends Command
@@ -57,7 +58,7 @@ class HorizonWorkerPreStop extends Command
         $startCommand = $this->option('start-command') ?: 'php artisan horizon';
 
         $pid = collect($masters->all())
-            ->filter(fn ($master) => str_starts_with($master->name, gethostname().':'))
+            ->filter(fn ($master) => str_starts_with($master->name, MasterSupervisor::basename().'-'))
             ->map(fn ($master) => (int) ($master->pid ?? 0))
             ->filter()
             ->first();

--- a/src/Commands/HorizonWorkerReadiness.php
+++ b/src/Commands/HorizonWorkerReadiness.php
@@ -8,6 +8,7 @@ use Goopil\LaravelRedisSentinel\Events\HorizonWorkerNotReady;
 use Goopil\LaravelRedisSentinel\Events\HorizonWorkerReady;
 use Illuminate\Console\Command;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
 
 class HorizonWorkerReadiness extends Command
 {
@@ -34,7 +35,7 @@ class HorizonWorkerReadiness extends Command
     public function handle(MasterSupervisorRepository $masters): int
     {
         $result = collect($masters->all())
-            ->filter(fn ($master) => str_starts_with($master->name, gethostname().':') &&
+            ->filter(fn ($master) => str_starts_with($master->name, MasterSupervisor::basename().'-') &&
                 $master->status === 'running'
             );
 

--- a/tests/Feature/Horizon/Commands/HorizonWorkerLivenessTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerLivenessTest.php
@@ -5,6 +5,7 @@ use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Facades\Artisan;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
 
 const HORIZON_LIVENESS_TEST_HOST = '127.0.0.1';
 
@@ -33,7 +34,7 @@ test('horizon:alive returns 0 when all checks pass', function () {
 
     // 3. Mock horizon:ready (returns 0 on success)
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
     $repository = Mockery::mock(MasterSupervisorRepository::class);
     $repository->allows('all')->andReturns([$master]);
@@ -64,7 +65,7 @@ test('horizon:alive uses setex with TTL for liveness check key', function () {
     app()->instance(RedisSentinelManager::class, $manager);
 
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
     $repository = Mockery::mock(MasterSupervisorRepository::class);
     $repository->allows('all')->andReturns([$master]);
@@ -93,7 +94,7 @@ test('horizon:alive returns 0 when sentinel returns associative array (phpredis 
     app()->instance(RedisSentinelManager::class, $manager);
 
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
     $repository = Mockery::mock(MasterSupervisorRepository::class);
     $repository->allows('all')->andReturns([$master]);
@@ -122,7 +123,7 @@ test('horizon:alive returns 1 when sentinel check fails (no master)', function (
     app()->instance(RedisSentinelManager::class, $manager);
 
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
     $repository = Mockery::mock(MasterSupervisorRepository::class);
     $repository->allows('all')->andReturns([$master]);
@@ -150,7 +151,7 @@ test('horizon:alive returns 1 when connection check fails', function () {
     app()->instance(RedisSentinelManager::class, $manager);
 
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
     $repository = Mockery::mock(MasterSupervisorRepository::class);
     $repository->allows('all')->andReturns([$master]);

--- a/tests/Feature/Horizon/Commands/HorizonWorkerPreStopTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerPreStopTest.php
@@ -4,6 +4,7 @@ use Goopil\LaravelRedisSentinel\Commands\HorizonWorkerPreStop;
 use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
 use Illuminate\Support\Facades\Artisan;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
 use Symfony\Component\Process\Process;
 
 test('horizon:pre-stop returns non-zero when no pid found', function () {
@@ -26,15 +27,13 @@ test('horizon:pre-stop does not match hostname as substring of another master', 
         $this->expectException(ConfigurationException::class);
     }
 
-    $realHostname = gethostname();
-
     $otherMaster = new stdClass;
-    $otherMaster->name = $realHostname.'0:1';
+    $otherMaster->name = MasterSupervisor::basename().'1-efgh';
     $otherMaster->pid = 99999;
     $otherMaster->status = 'running';
 
     $ourMaster = new stdClass;
-    $ourMaster->name = $realHostname.':1';
+    $ourMaster->name = MasterSupervisor::basename().'-abcd';
     $ourMaster->pid = 88888;
     $ourMaster->status = 'running';
 

--- a/tests/Feature/Horizon/Commands/HorizonWorkerReadynessTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerReadynessTest.php
@@ -57,10 +57,8 @@ test('horizon:ready returns 1 when master is for another host', function () {
 });
 
 test('horizon:ready does not match hostname as substring of another host', function () {
-    $realHostname = gethostname();
-
     $otherMaster = new stdClass;
-    $otherMaster->name = $realHostname.'0:1';
+    $otherMaster->name = MasterSupervisor::basename().'0-efgh';
     $otherMaster->status = 'running';
 
     $repository = Mockery::mock(MasterSupervisorRepository::class);

--- a/tests/Feature/Horizon/Commands/HorizonWorkerReadynessTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerReadynessTest.php
@@ -2,10 +2,11 @@
 
 use Illuminate\Support\Facades\Artisan;
 use Laravel\Horizon\Contracts\MasterSupervisorRepository;
+use Laravel\Horizon\MasterSupervisor;
 
 test('horizon:ready returns 0 when master is running for this host', function () {
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
 
     $repository = Mockery::mock(MasterSupervisorRepository::class);
@@ -29,7 +30,7 @@ test('horizon:ready returns 1 when no master is running', function () {
 
 test('horizon:ready returns 1 when master is not running', function () {
     $master = new stdClass;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'paused';
 
     $repository = Mockery::mock(MasterSupervisorRepository::class);

--- a/tests/Feature/Horizon/HorizonCommandEventsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandEventsTest.php
@@ -308,7 +308,7 @@ describe('Horizon Command Events', function () {
             $mock->expects('all')->andReturn([$extended]);
         });
 
-        Artisan::call('horizon:pre-stop');
+        Artisan::call('horizon:pre-stop', ['--start-command' => 'definitely-not-running-xyz']);
 
         Event::assertDispatched(HorizonWorkerTerminateFailed::class, function (HorizonWorkerTerminateFailed $event) {
             return $event->pid === null;

--- a/tests/Feature/Horizon/HorizonCommandEventsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandEventsTest.php
@@ -21,7 +21,7 @@ const HORIZON_EVENTS_NOT_INSTALLED = 'Horizon not installed';
 function horizonEventsRunningMaster(): MasterSupervisor
 {
     $master = new MasterSupervisor;
-    $master->name = gethostname().':1';
+    $master->name = MasterSupervisor::basename().'-tst1';
     $master->status = 'running';
 
     return $master;
@@ -106,7 +106,7 @@ describe('Horizon Command Events', function () {
         }
 
         $master = new MasterSupervisor;
-        $master->name = gethostname().':1';
+        $master->name = MasterSupervisor::basename().'-tst1';
         $master->status = 'paused';
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($master) {
@@ -139,7 +139,7 @@ describe('Horizon Command Events', function () {
         });
 
         $master = new MasterSupervisor;
-        $master->name = gethostname().':1';
+        $master->name = MasterSupervisor::basename().'-tst1';
         $master->status = 'paused';
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($master) {
@@ -236,7 +236,7 @@ describe('Horizon Command Events', function () {
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
             $master = new MasterSupervisor;
-            $master->name = gethostname().':1';
+            $master->name = MasterSupervisor::basename().'-tst1';
             $master->pid = 999999; // Non-existent PID likely
 
             $mock->expects('all')->andReturn([$master]);
@@ -274,7 +274,7 @@ describe('Horizon Command Events', function () {
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) use ($pid) {
             $master = new MasterSupervisor;
-            $master->name = gethostname().':1';
+            $master->name = MasterSupervisor::basename().'-tst1';
             $master->pid = $pid;
 
             $mock->expects('all')->andReturn([$master]);
@@ -289,5 +289,29 @@ describe('Horizon Command Events', function () {
         });
 
         Event::assertNotDispatched(HorizonWorkerTerminateFailed::class);
+    });
+
+    test('horizon:pre-stop ignores masters whose hostname extends ours', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_EVENTS_NOT_INSTALLED);
+        }
+
+        if (! extension_loaded('pcntl') || ! extension_loaded('posix')) {
+            $this->markTestSkipped('pcntl or posix extension not loaded');
+        }
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $extended = new MasterSupervisor;
+            $extended->name = MasterSupervisor::basename().'1-efgh';
+            $extended->pid = 555555;
+
+            $mock->expects('all')->andReturn([$extended]);
+        });
+
+        Artisan::call('horizon:pre-stop');
+
+        Event::assertDispatched(HorizonWorkerTerminateFailed::class, function (HorizonWorkerTerminateFailed $event) {
+            return $event->pid === null;
+        });
     });
 });

--- a/tests/Feature/Horizon/HorizonCommandsTest.php
+++ b/tests/Feature/Horizon/HorizonCommandsTest.php
@@ -36,7 +36,7 @@ describe('Horizon Commands', function () {
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
             $master = new MasterSupervisor;
-            $master->name = gethostname().':1';
+            $master->name = MasterSupervisor::basename().'-tst1';
             $master->status = 'running';
 
             $mock->expects('all')->andReturn([$master]);
@@ -67,7 +67,7 @@ describe('Horizon Commands', function () {
         // Mock horizon:ready to return 0
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
             $master = new MasterSupervisor;
-            $master->name = gethostname().':1';
+            $master->name = MasterSupervisor::basename().'-tst1';
             $master->status = 'running';
             $mock->expects('all')->andReturn([$master]);
         });
@@ -94,7 +94,7 @@ describe('Horizon Commands', function () {
 
         $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
             $master = new MasterSupervisor;
-            $master->name = gethostname().':1';
+            $master->name = MasterSupervisor::basename().'-tst1';
             $master->pid = 999999; // Non-existent PID likely
             $mock->expects('all')->andReturn([$master]);
         });
@@ -103,6 +103,44 @@ describe('Horizon Commands', function () {
         // The command reports the failure and returns 1.
 
         $exitCode = Artisan::call('horizon:pre-stop');
+        expect($exitCode)->toBe(1);
+    });
+
+    test('horizon:ready does not match a master whose hostname extends ours', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_NOT_INSTALLED);
+        }
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $mine = new MasterSupervisor;
+            $mine->name = MasterSupervisor::basename().'-abcd';
+            $mine->status = 'running';
+
+            $extended = new MasterSupervisor;
+            $extended->name = MasterSupervisor::basename().'1-efgh'; // worker-11 when we are worker-1
+            $extended->status = 'running';
+
+            $mock->expects('all')->andReturn([$mine, $extended]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
+        expect($exitCode)->toBe(0);
+    });
+
+    test('horizon:ready returns 1 when only an extended-hostname master is running', function () {
+        if (! interface_exists(MasterSupervisorRepository::class)) {
+            $this->markTestSkipped(HORIZON_NOT_INSTALLED);
+        }
+
+        $this->mock(MasterSupervisorRepository::class, function (MockInterface $mock) {
+            $extended = new MasterSupervisor;
+            $extended->name = MasterSupervisor::basename().'1-efgh';
+            $extended->status = 'running';
+
+            $mock->expects('all')->twice()->andReturn([$extended]);
+        });
+
+        $exitCode = Artisan::call('horizon:ready');
         expect($exitCode)->toBe(1);
     });
 });


### PR DESCRIPTION
Closes #61

## Summary

The `horizon:ready` and `horizon:pre-stop` commands filtered master supervisors with `str_starts_with($master->name, gethostname().':')`. Two problems, both worse than the issue described:

1. **The filter never matches real Horizon masters.** Horizon ^5.29 builds master names as `Str::slug(gethostname()).'-'.Str::random(4)` (e.g. `worker-1-kX9p`) — there is no `hostname:` prefix in real names (the format existed only in this package's own test mocks). In production, `horizon:ready` always returned not-ready.
2. **The worker-1/worker-11 ambiguity** from the issue: any hostname that is a substring of another could match the wrong master.

## Fix

Filter on `MasterSupervisor::basename().'-'`:
- matches the real Horizon name format exactly (deterministic part of the name; the random token cannot be reconstructed),
- is exact for the hostname (`worker-11-token` does not start with `worker-1-`),
- respects Horizon's `$nameResolver`,
- strictly tighter than Horizon's own `TerminateCommand`, which uses a bare `Str::startsWith($name, basename())` without any delimiter.

Residual note: a hostname that is a strict slug-prefix of another (`worker` vs `worker-11`) remains ambiguous — this is inherent to Horizon's naming scheme and identical to Horizon's own grouping semantics; nothing stricter is possible without the token.

## Changes

- `src/Commands/HorizonWorkerReadiness.php`, `src/Commands/HorizonWorkerPreStop.php` — filter + import
- All Horizon test mocks migrated from the fake `gethostname().':1'` format to real-format names (including two `Commands/` test files missed by the initial pass and caught in review)
- New tests: worker-1/worker-11 pair for `horizon:ready` (exactly-one match, and only-extended-hostname → exit 1), and `horizon:pre-stop` ignores an extended-hostname master (falls back to pgrep with a non-matching start command — no real `pgrep -f 'php artisan horizon'` is ever run, so no risk of SIGTERMing a live process)

## Verification

- Full suite: 514 passed (0 failed)
- Pint + phpstan clean
- without-Horizon job unaffected: commands register only when Horizon is bound; all `MasterSupervisor` references live inside the CI-excluded `tests/Feature/Horizon/` tree