### PR TITLE
ci: remove npm install fallback so lockfile drift fails loudly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         run: composer audit
 
       - name: Install npm dependencies
-        run: npm ci || npm install
+        run: npm ci
 
       - name: npm audit
         run: npm audit --audit-level=high


### PR DESCRIPTION
Closes #64

## Summary

The security-audit job ran `npm ci || npm install`. The fallback silently masks lockfile drift — exactly what the audit job should catch — and `npm install` can resolve a dependency tree different from the committed lockfile.

Now: bare `npm ci`. If the lockfile is out of sync, the job fails and the offending PR fixes it.

## Notes

- Verified `npm ci --dry-run` succeeds against the current lockfile (315 packages, in sync), so main won't break.
- Follow-up (out of scope): `.github/workflows/release.yml:32` uses a bare `npm install` — same non-reproducibility class; candidate for a small follow-up `ci:` commit pinning it to `npm ci`.
- `ci:` produces no release (default semantic-release rules), as appropriate for a CI-only change.