### PR TITLE
fix: namespace node address cache keys per Sentinel cluster endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ return [
 - The data client uses strictly `password`; `sentinel.password` only authenticates against Sentinel nodes.
 - `retry.redis.messages` can be overridden **per connection** (`retry.redis.messages` inside the connection config), like `attempts`/`delay`. See the [Retry contract](#retry-contract) for the at-least-once implications.
 - Resolved master/replica addresses are cached with a TTL: `phpredis-sentinel.node_cache.ttl` (seconds, default `15`; `0`
-  disables expiry — discouraged, it delays failover detection in long-lived workers).
+  disables expiry and negative values behave like `0` — discouraged, it delays failover detection in long-lived workers).
+  Cache entries are namespaced per Sentinel cluster (service name + sentinel endpoints), so two connections sharing a
+  service name across different clusters never exchange cached addresses.
 
 > If you previously published the config file, your copy still defaults to `env('REDIS_SENTINEL_NODE_CACHE_TTL', 0)` — set the env var or update your copy to get the new 15 s default.
 

--- a/src/Connectors/NodeAddressCache.php
+++ b/src/Connectors/NodeAddressCache.php
@@ -2,6 +2,8 @@
 
 namespace Goopil\LaravelRedisSentinel\Connectors;
 
+use Closure;
+
 final class NodeAddressCache
 {
     private const MASTER_KEY = 'master';
@@ -13,7 +15,7 @@ final class NodeAddressCache
      */
     protected array $nodes = [];
 
-    public function __construct(protected float $ttlSeconds = 0.0) {}
+    public function __construct(protected float $ttlSeconds = 0.0, protected ?Closure $clock = null) {}
 
     /**
      * Get the cached master address for a service.
@@ -109,13 +111,18 @@ final class NodeAddressCache
         $this->nodes = [];
     }
 
+    private function now(): float
+    {
+        return $this->clock ? ($this->clock)() : microtime(true);
+    }
+
     private function expiresAt(): ?float
     {
-        return $this->ttlSeconds > 0 ? microtime(true) + $this->ttlSeconds : null;
+        return $this->ttlSeconds > 0 ? $this->now() + $this->ttlSeconds : null;
     }
 
     private function isExpired(?float $expiresAt): bool
     {
-        return $expiresAt !== null && microtime(true) >= $expiresAt;
+        return $expiresAt !== null && $this->now() >= $expiresAt;
     }
 }

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -400,7 +400,7 @@ class RedisSentinelConnector extends PhpRedisConnector
      *
      * @param  array<string, mixed>  $config
      */
-    private function getNodeCacheKey(array $config): string
+    public function getNodeCacheKey(array $config): string
     {
         $service = $this->getService($config) ?? '';
 
@@ -410,7 +410,7 @@ class RedisSentinelConnector extends PhpRedisConnector
             $host = $this->normalizeHost($sentinel['host'] ?? '');
             $port = $this->normalizePort($sentinel['port'] ?? null);
 
-            if ($host === null) {
+            if ($host === null || $port === null) {
                 continue;
             }
 

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -180,10 +180,10 @@ class RedisSentinelConnector extends PhpRedisConnector
         $service = $this->getService($config);
 
         if ($refresh) {
-            $this->masterCache->forgetMaster($service);
+            $this->masterCache->forgetMaster($this->getNodeCacheKey($config));
         }
 
-        if ($master = $this->masterCache->get($service)) {
+        if ($master = $this->masterCache->get($this->getNodeCacheKey($config))) {
             return $master;
         }
 
@@ -212,7 +212,7 @@ class RedisSentinelConnector extends PhpRedisConnector
             onMaxFail: $this->onSentinelMaxFail($service, 'getMasterAddress')
         );
 
-        $this->masterCache->set($service, $ip, $port);
+        $this->masterCache->set($this->getNodeCacheKey($config), $ip, $port);
 
         return ['ip' => $ip, 'port' => $port];
     }
@@ -227,10 +227,10 @@ class RedisSentinelConnector extends PhpRedisConnector
         $service = $this->getService($config);
 
         if ($refresh) {
-            $this->masterCache->forgetReplicas($service);
+            $this->masterCache->forgetReplicas($this->getNodeCacheKey($config));
         }
 
-        $replicas = $this->masterCache->getReplicas($service);
+        $replicas = $this->masterCache->getReplicas($this->getNodeCacheKey($config));
 
         if (empty($replicas)) {
             $this->guardSentinelResolution();
@@ -277,7 +277,7 @@ class RedisSentinelConnector extends PhpRedisConnector
                 return $this->getMasterAddress($config, $refresh);
             }
 
-            $this->masterCache->setReplicas($service, $replicas);
+            $this->masterCache->setReplicas($this->getNodeCacheKey($config), $replicas);
         }
 
         $replica = $replicas[random_int(0, count($replicas) - 1)];
@@ -391,6 +391,35 @@ class RedisSentinelConnector extends PhpRedisConnector
         self::$resolutionFailures = 0;
         self::$breakerOpenedAt = null;
         self::$breakerLastException = null;
+    }
+
+    /**
+     * Namespace the node cache key by service name and Sentinel endpoints so two
+     * connections pointing at different clusters sharing a service name never
+     * exchange cached addresses.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    private function getNodeCacheKey(array $config): string
+    {
+        $service = $this->getService($config) ?? '';
+
+        $endpoints = [];
+
+        foreach ($this->getSentinels($config) as $sentinel) {
+            $host = $this->normalizeHost($sentinel['host'] ?? '');
+            $port = $this->normalizePort($sentinel['port'] ?? null);
+
+            if ($host === null) {
+                continue;
+            }
+
+            $endpoints[] = $host.':'.$port;
+        }
+
+        sort($endpoints);
+
+        return $service.'-'.sha1(implode(',', $endpoints));
     }
 
     protected function getService(array $config): ?string

--- a/tests/Feature/ConnectionRetryTest.php
+++ b/tests/Feature/ConnectionRetryTest.php
@@ -136,7 +136,7 @@ describe('Reconnect', function () {
         expect($failoverTriggered)->toBeTrue('Failover command should succeed after retries');
 
         // Invalidate the cache after failover to ensure the package will fetch the new master
-        app(NodeAddressCache::class)->forget('master');
+        app(NodeAddressCache::class)->forget(sentinelNodeCacheKey());
 
         // Wait for Sentinel to converge on the new master (failover can take
         // up to ~30s on a fresh CI setup, so poll up to 30s).

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -518,7 +518,7 @@ test('it keeps cached master address when refreshing replicas', function () {
     expect($connector->master($config))->toBe(['ip' => HOST_1, 'port' => 6379]);
     expect($connector->replica($config))->toBe(['ip' => HOST_2, 'port' => 6379]);
     expect($connector->replica($config, true))->toBe(['ip' => HOST_3, 'port' => 6379]);
-    expect($cache->get('mymaster'))->toBe(['ip' => HOST_1, 'port' => 6379]);
+    expect($cache->get($connector->getNodeCacheKey($config)))->toBe(['ip' => HOST_1, 'port' => 6379]);
 });
 
 test('it reindexes healthy replicas after filtering unhealthy replicas', function () {
@@ -558,13 +558,15 @@ test('it reindexes healthy replicas after filtering unhealthy replicas', functio
         }
     };
 
-    $connection = $connector->connect([
+    $config = [
         'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
         'read_only_replicas' => true,
-    ], []);
+    ];
+
+    $connection = $connector->connect($config, []);
 
     expect($connection->getReadClient()->getHost())->toBeIn([HOST_3, HOST_4]);
-    expect(array_keys($cache->getReplicas('mymaster')))->toBe([0, 1]);
+    expect(array_keys($cache->getReplicas($connector->getNodeCacheKey($config))))->toBe([0, 1]);
 });
 
 test('it falls back to master if all replicas are unhealthy', function () {

--- a/tests/Feature/Toxiproxy/FailoverTest.php
+++ b/tests/Feature/Toxiproxy/FailoverTest.php
@@ -38,7 +38,6 @@ describe('Real Sentinel failover through toxiproxy', function () {
     });
 
     test('stale master connection retries and lands on the promoted master', function () {
-        $service = (string) config('database.redis.phpredis-sentinel.sentinel.service', 'master');
         $connection = Redis::connection('phpredis-sentinel');
         expect($connection->set('chaos_stale', 'v1'))->toBeTrue();
 
@@ -58,7 +57,7 @@ describe('Real Sentinel failover through toxiproxy', function () {
         expect($this->reissueUntilSuccess(fn () => $connection->set('chaos_stale', 'v2'), attempts: 20))->toBeTrue()
             ->and($connection->get('chaos_stale'))->toBe('v2');
 
-        $cached = app(NodeAddressCache::class)->get($service);
+        $cached = app(NodeAddressCache::class)->get(sentinelNodeCacheKey());
         expect($cached['port'])->toBe($newAddress['port'], 'NodeAddressCache must point at the promoted master');
 
         app('redis')->purge('phpredis-sentinel');
@@ -68,7 +67,6 @@ describe('Real Sentinel failover through toxiproxy', function () {
     test('stale node address cache writes to the demoted master, hits READONLY and recovers', function () {
         Event::fake([RedisSentinelConnectionReconnected::class]);
 
-        $service = (string) config('database.redis.phpredis-sentinel.sentinel.service', 'master');
         $connection = Redis::connection('phpredis-sentinel');
         expect($connection->set('chaos_readonly', 'v1'))->toBeTrue();
 
@@ -85,7 +83,7 @@ describe('Real Sentinel failover through toxiproxy', function () {
         // Prime the in-process address cache with the demoted node, mimicking a
         // long-running process (Octane, queue workers) whose cached master address
         // survived the failover, then force a fresh connection to read that cache
-        app(NodeAddressCache::class)->set($service, $oldAddress['ip'], $oldAddress['port']);
+        app(NodeAddressCache::class)->set(sentinelNodeCacheKey(), $oldAddress['ip'], $oldAddress['port']);
         $this->purgeSentinelConnection();
 
         $stale = Redis::connection('phpredis-sentinel');
@@ -98,7 +96,7 @@ describe('Real Sentinel failover through toxiproxy', function () {
 
         Event::assertDispatched(RedisSentinelConnectionReconnected::class);
 
-        $cached = app(NodeAddressCache::class)->get($service);
+        $cached = app(NodeAddressCache::class)->get(sentinelNodeCacheKey());
         expect($cached['port'])->toBe($newAddress['port'], 'Cache must be refreshed to the promoted master');
     });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,7 @@
 */
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
 use Goopil\LaravelRedisSentinel\Tests\Support\Toxiproxy\InteractsWithToxiproxy;
 use Goopil\LaravelRedisSentinel\Tests\TestCase;
 use Illuminate\Redis\Connections\PhpRedisConnection;
@@ -73,6 +74,16 @@ expect()->extend('toBeAWorkingRedisConnection', function () {
 function getRedisSentinelConnection()
 {
     return app()->get('redis')->connection('phpredis-sentinel');
+}
+
+/**
+ * The namespaced NodeAddressCache key the connector derives for the
+ * phpredis-sentinel connection, so tests read the exact keys production writes.
+ */
+function sentinelNodeCacheKey(): string
+{
+    return app(RedisSentinelConnector::class)
+        ->getNodeCacheKey((array) config('database.redis.phpredis-sentinel'));
 }
 
 function getRedisConnection()

--- a/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
+++ b/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
@@ -198,8 +198,7 @@ trait InteractsWithToxiproxy
      */
     public function connectedMasterPort(): int
     {
-        $service = (string) config('database.redis.phpredis-sentinel.sentinel.service', 'master');
-        $cached = app(NodeAddressCache::class)->get($service);
+        $cached = app(NodeAddressCache::class)->get(sentinelNodeCacheKey());
 
         if ($cached === null) {
             throw new RuntimeException('NodeAddressCache holds no master address for the established connection.');

--- a/tests/Unit/Connectors/NodeAddressCacheIsolationTest.php
+++ b/tests/Unit/Connectors/NodeAddressCacheIsolationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+
+beforeEach(function () {
+    foreach (['resolutionFailures', 'breakerOpenedAt', 'breakerLastException'] as $property) {
+        $ref = new ReflectionProperty(RedisSentinelConnector::class, $property);
+        $ref->setAccessible(true);
+        $ref->setValue(null, match ($property) {
+            'resolutionFailures' => 0,
+            default => null,
+        });
+    }
+});
+
+function isolatedConnector(): RedisSentinelConnector
+{
+    return new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public function getMasterAddress(array $config, bool $refresh = false): array
+        {
+            return parent::getMasterAddress($config, $refresh);
+        }
+
+        protected function createSentinelInstance(array $options): RedisSentinel
+        {
+            $sentinel = Mockery::mock(RedisSentinel::class);
+            $sentinel->shouldReceive('ping')->andReturnTrue();
+            $sentinel->shouldReceive('master')->with('mymaster')->andReturnUsing(function () use ($options) {
+                return ['ip' => $options['host'], 'port' => 6380];
+            });
+
+            return $sentinel;
+        }
+    };
+}
+
+test('same service name on different sentinel clusters resolves distinct masters', function () {
+    $connector = isolatedConnector();
+
+    $clusterA = [
+        'sentinels' => [['host' => '10.0.0.1', 'port' => 26379]],
+        'sentinel' => ['service' => 'mymaster'],
+    ];
+    $clusterB = [
+        'sentinels' => [['host' => '10.0.0.2', 'port' => 26379]],
+        'sentinel' => ['service' => 'mymaster'],
+    ];
+
+    $masterA = $connector->getMasterAddress($clusterA);
+    $masterB = $connector->getMasterAddress($clusterB);
+
+    expect($masterA)->toBe(['ip' => '10.0.0.1', 'port' => 6380])
+        ->and($masterB)->toBe(['ip' => '10.0.0.2', 'port' => 6380]);
+});
+
+test('same cluster with reordered sentinel list hits the same cache key', function () {
+    $connector = isolatedConnector();
+
+    $configA = [
+        'sentinels' => [
+            ['host' => '10.0.0.1', 'port' => 26379],
+            ['host' => '10.0.0.2', 'port' => 26379],
+        ],
+        'sentinel' => ['service' => 'mymaster'],
+    ];
+    $configB = [
+        'sentinels' => [
+            ['host' => '10.0.0.2', 'port' => 26379],
+            ['host' => '10.0.0.1', 'port' => 26379],
+        ],
+        'sentinel' => ['service' => 'mymaster'],
+    ];
+
+    expect($connector->getMasterAddress($configA))->toBe(['ip' => '10.0.0.1', 'port' => 6380])
+        ->and($connector->getMasterAddress($configB))->toBe(['ip' => '10.0.0.1', 'port' => 6380]);
+});

--- a/tests/Unit/NodeAddressCacheTest.php
+++ b/tests/Unit/NodeAddressCacheTest.php
@@ -77,7 +77,10 @@ test('forgetMaster removes service entry when no replicas remain', function () {
 });
 
 test('entries expire after the configured ttl', function () {
-    $cache = new NodeAddressCache(0.01);
+    $now = 1000.0;
+    $cache = new NodeAddressCache(0.01, function () use (&$now) {
+        return $now;
+    });
 
     $cache->set('svc', '127.0.0.1', 6379);
     $cache->setReplicas('svc', [['ip' => '127.0.0.1', 'port' => 6380]]);
@@ -85,31 +88,49 @@ test('entries expire after the configured ttl', function () {
     expect($cache->get('svc'))->toBe(['ip' => '127.0.0.1', 'port' => 6379])
         ->and($cache->getReplicas('svc'))->toBe([['ip' => '127.0.0.1', 'port' => 6380]]);
 
-    usleep(20000);
+    $now = 1000.011;
 
     expect($cache->get('svc'))->toBeNull()
         ->and($cache->getReplicas('svc'))->toBe([]);
 });
 
 test('ttl zero keeps entries forever (backwards compatible)', function () {
-    $cache = new NodeAddressCache(0.0);
+    $now = 1000.0;
+    $cache = new NodeAddressCache(0.0, function () use (&$now) {
+        return $now;
+    });
 
     $cache->set('svc', '127.0.0.1', 6379);
     $cache->setReplicas('svc', [['ip' => '127.0.0.1', 'port' => 6380]]);
 
-    usleep(20000);
+    $now = 2000.0;
 
     expect($cache->get('svc'))->toBe(['ip' => '127.0.0.1', 'port' => 6379])
         ->and($cache->getReplicas('svc'))->toBe([['ip' => '127.0.0.1', 'port' => 6380]]);
 });
 
 test('expiring one entry type keeps the other', function () {
-    $cache = new NodeAddressCache(0.01);
+    $now = 1000.0;
+    $cache = new NodeAddressCache(0.01, function () use (&$now) {
+        return $now;
+    });
 
     $cache->set('svc', '127.0.0.1', 6379);
-    usleep(20000);
+    $now = 1000.011;
     $cache->setReplicas('svc', [['ip' => '127.0.0.2', 'port' => 6380]]);
 
     expect($cache->get('svc'))->toBeNull()
         ->and($cache->getReplicas('svc'))->toBe([['ip' => '127.0.0.2', 'port' => 6380]]);
+});
+
+test('negative ttl behaves like zero (no expiry)', function () {
+    $now = 1000.0;
+    $cache = new NodeAddressCache(-5.0, function () use (&$now) {
+        return $now;
+    });
+
+    $cache->set('svc', '127.0.0.1', 6379);
+    $now = 2000.0;
+
+    expect($cache->get('svc'))->toBe(['ip' => '127.0.0.1', 'port' => 6379]);
 });


### PR DESCRIPTION
Closes #62
Closes #37

## Summary

`NodeAddressCache` keyed entries by service name only. Two connections in one process pointing at **different Sentinel clusters** exposing the same service name (multi-tenant/test setups with two `mymaster`s) shared one cache entry: connection B received connection A's master address — potentially pointing it at a foreign cluster.

## Changes

**Cache key namespacing (#62)** — the connector now derives `getNodeCacheKey(config)` = `service + '-' + sha1(sorted normalized 'host:port' sentinel list)` and uses it at all six cache call sites (`forgetMaster`/`get`/`set`/`forgetReplicas`/`getReplicas`/`setReplicas`). Events, logs and the replica-fallback dispatch keep the plain service name. The helper is public so tests and the toxiproxy support derive the same key without reflection. Sorting makes the key insensitive to sentinel list order; normalized endpoints make it insensitive to config formatting.

**Deterministic TTL tests (#37)** — `NodeAddressCache` accepts an injectable clock (`?Closure $now`, defaults to `microtime(true)`); the three timing tests no longer depend on a 10 ms TTL / 20 ms sleep window (zero `usleep` remaining), and a negative-TTL row pins the "negative behaves like 0" semantics.

**Docs (#37)** — README documents `0` disables expiry, negatives behave like `0`, and the per-cluster namespacing.

## Verification

- Isolation test proven **red pre-fix** (cluster B received cluster A's master through the shared `mymaster` key) and green post-fix; second test pins sort-order insensitivity.
- Review round 1 caught five plain-key reads left in test support (`ReadWriteSplittingTest`, `InteractsWithToxiproxy.connectedMasterPort`, `FailoverTest` stale-cache seed, `ConnectionRetryTest.forget`) — all converted; the toxiproxy chaos suite then ran for real (overlay up) and passed, exercising the namespaced stale-cache seed through an actual failover.
- Full suite: 531 passed (0 failed), Pint + phpstan clean.
- `fix:` → patch; the `test:` commit (clock + docs) produces no release and is runtime-independent from the fix commit.