### PR TITLE
fix: correct flushall/flushdb ASYNC semantics and select the argument per installed phpredis major

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,8 +708,9 @@ your own Redis topology, workload, and deployment model.
   socket now fails after 60s instead of hanging the worker forever. Set `read_timeout: 0` for unbounded blocking reads, and
   always keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
 - **`flushdb($async)` / `flushall($sync)` flush semantics are normalized**: `flushdb(async: true)` and `flushall(sync: false)`
-  send `ASYNC` explicitly; any other value (including the defaults) performs a blocking flush. Parameter names follow
-  phpredis's signatures, so `sync: false` / `async: true` are the asynchronous forms.
+  request a non-blocking flush. The package sends the argument that selects ASYNC on the installed phpredis major (`false` on
+  phpredis 6.x, the literal `'ASYNC'` on 5.x); any other value (including the defaults) performs a blocking flush.
+  Blocking-vs-async remains best-effort: do not rely on the flag for strict ordering guarantees.
 - **Laravel's built-in command retry is disabled for this connection**: Laravel 13+ wraps `command()` with an internal single
   retry whose connector is not Sentinel-aware and dispatches no events. This connection overrides `isRetryable()` to turn it
   off, so the package's `retry()` layer stays the single retry path and `RedisSentinelConnectionFailed` /

--- a/README.md
+++ b/README.md
@@ -707,9 +707,9 @@ your own Redis topology, workload, and deployment model.
 - **`read_timeout` defaults to 60 seconds** (both the Redis client and the Sentinel client): a blocking command on a half-open
   socket now fails after 60s instead of hanging the worker forever. Set `read_timeout: 0` for unbounded blocking reads, and
   always keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
-- **`flushdb($async)` / `flushall($sync)` flags are not reliably forwarded**: on phpredis 6.x the flag is ignored (commands
-  run synchronously); on older 5.x releases a truthy argument may be sent as `ASYNC`. Do not rely on the parameter for
-  predictable background flushing.
+- **`flushdb($async)` / `flushall($sync)` flush semantics are normalized**: `flushdb(async: true)` and `flushall(sync: false)`
+  send `ASYNC` explicitly; any other value (including the defaults) performs a blocking flush. Parameter names follow
+  phpredis's signatures, so `sync: false` / `async: true` are the asynchronous forms.
 - **Laravel's built-in command retry is disabled for this connection**: Laravel 13+ wraps `command()` with an internal single
   retry whose connector is not Sentinel-aware and dispatches no events. This connection overrides `isRetryable()` to turn it
   off, so the package's `retry()` layer stays the single retry path and `RedisSentinelConnectionFailed` /

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -109,12 +109,6 @@ parameters:
 			path: src/Connections/RedisSentinelConnection.php
 
 		-
-			message: '#^Method Goopil\\LaravelRedisSentinel\\Connections\\RedisSentinelConnection\:\:flushdb\(\) has parameter \$async with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Connections/RedisSentinelConnection.php
-
-		-
 			message: '#^Method Goopil\\LaravelRedisSentinel\\Connections\\RedisSentinelConnection\:\:hscan\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -212,7 +212,7 @@ class RedisSentinelConnection extends PhpRedisConnection
     public function flushdb($async = null): mixed
     {
         try {
-            return parent::flushdb($async);
+            return $this->command('flushdb', $async ? ['ASYNC'] : []);
         } finally {
             // Reset stickiness after flushing since all data is gone
             $this->wroteToMaster = false;
@@ -227,7 +227,7 @@ class RedisSentinelConnection extends PhpRedisConnection
     public function flushall(?bool $sync = null): bool|\Redis
     {
         try {
-            return $this->command('flushall', $sync ? ['ASYNC'] : []);
+            return $this->command('flushall', $sync === false ? ['ASYNC'] : []);
         } finally {
             // Reset stickiness after flushing since all data is gone
             $this->wroteToMaster = false;

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -207,12 +207,14 @@ class RedisSentinelConnection extends PhpRedisConnection
     /**
      * Remove all keys from the current database and reset stickiness.
      *
+     * @param  bool|null  $async  true requests a non-blocking flush, null/false blocks
+     *
      * @throws Throwable
      */
     public function flushdb($async = null): mixed
     {
         try {
-            return $this->command('flushdb', $async ? ['ASYNC'] : []);
+            return $this->command('flushdb', $this->asyncFlushArguments((bool) $async));
         } finally {
             // Reset stickiness after flushing since all data is gone
             $this->wroteToMaster = false;
@@ -222,16 +224,37 @@ class RedisSentinelConnection extends PhpRedisConnection
     /**
      * Remove all keys from all databases and reset stickiness.
      *
+     * @param  bool|null  $sync  true/null perform a blocking flush, false requests a non-blocking flush
+     *
      * @throws Throwable
      */
     public function flushall(?bool $sync = null): bool|\Redis
     {
         try {
-            return $this->command('flushall', $sync === false ? ['ASYNC'] : []);
+            return $this->command('flushall', $sync === false ? $this->asyncFlushArguments(true) : []);
         } finally {
             // Reset stickiness after flushing since all data is gone
             $this->wroteToMaster = false;
         }
+    }
+
+    /**
+     * phpredis 5.x selects ASYNC for any truthy argument; phpredis 6.x flipped the
+     * meaning (true = SYNC, false = ASYNC) — verified on the wire with MONITOR.
+     * Return the argument list that selects ASYNC on the installed extension,
+     * or an empty list for a blocking flush.
+     *
+     * @return array<int, bool|string>
+     */
+    private function asyncFlushArguments(bool $async): array
+    {
+        if (! $async) {
+            return [];
+        }
+
+        return version_compare((string) phpversion('redis'), '6.0', '>=')
+            ? [false]
+            : ['ASYNC'];
     }
 
     /**

--- a/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
@@ -2,7 +2,7 @@
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 
-test('flushall sends ASYNC only when sync is false', function (?bool $sync, array $expectedArgs) {
+test('flushall sends the ASYNC selector only when sync is false', function (?bool $sync, array $expectedArgs) {
     $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
     $connection->shouldReceive('command')->once()->with('flushall', $expectedArgs)->andReturnTrue();
 
@@ -10,17 +10,17 @@ test('flushall sends ASYNC only when sync is false', function (?bool $sync, arra
 })->with([
     'default sync' => [null, []],
     'explicit sync' => [true, []],
-    'async' => [false, ['ASYNC']],
+    'async' => [false, expectedAsyncFlushArgs()],
 ]);
 
-test('flushdb sends ASYNC only when async is true', function ($async, array $expectedArgs) {
+test('flushdb sends the ASYNC selector only when async is true', function ($async, array $expectedArgs) {
     $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
     $connection->shouldReceive('command')->once()->with('flushdb', $expectedArgs)->andReturnTrue();
 
     expect($connection->flushdb($async))->toBeTrue();
 })->with([
     'default sync' => [null, []],
-    'async' => [true, ['ASYNC']],
+    'async' => [true, expectedAsyncFlushArgs()],
     'explicit sync' => [false, []],
 ]);
 
@@ -28,9 +28,19 @@ test('flush methods reset master stickiness even when the command fails', functi
     $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
     $connection->shouldReceive('command')->once()->with('flushall', [])->andThrow(new RuntimeException('boom'));
 
-    expect(fn () => $connection->flushall())->toThrow(RuntimeException::class);
-
     $stickiness = new ReflectionProperty(RedisSentinelConnection::class, 'wroteToMaster');
+    $stickiness->setValue($connection, true);
 
-    expect($stickiness->getValue($connection))->toBeFalse();
+    expect(fn () => $connection->flushall())->toThrow(RuntimeException::class)
+        ->and($stickiness->getValue($connection))->toBeFalse();
 });
+
+/**
+ * phpredis 6.x inverted flushall/flushdb argument semantics (true = SYNC, false = ASYNC,
+ * verified on the wire with MONITOR); 5.x selected ASYNC for any truthy argument. The
+ * async rows must assert what the installed runtime sends.
+ */
+function expectedAsyncFlushArgs(): array
+{
+    return version_compare((string) phpversion('redis'), '6.0', '>=') ? [false] : ['ASYNC'];
+}

--- a/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+
+test('flushall sends ASYNC only when sync is false', function (?bool $sync, array $expectedArgs) {
+    $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
+    $connection->shouldReceive('command')->once()->with('flushall', $expectedArgs)->andReturnTrue();
+
+    expect($connection->flushall($sync))->toBeTrue();
+})->with([
+    'default sync' => [null, []],
+    'explicit sync' => [true, []],
+    'async' => [false, ['ASYNC']],
+]);
+
+test('flushdb sends ASYNC only when async is true', function ($async, array $expectedArgs) {
+    $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
+    $connection->shouldReceive('command')->once()->with('flushdb', $expectedArgs)->andReturnTrue();
+
+    expect($connection->flushdb($async))->toBeTrue();
+})->with([
+    'default sync' => [null, []],
+    'async' => [true, ['ASYNC']],
+    'explicit sync' => [false, []],
+]);
+
+test('flush methods reset master stickiness even when the command fails', function () {
+    $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
+    $connection->shouldReceive('command')->once()->with('flushall', [])->andThrow(new RuntimeException('boom'));
+
+    expect(fn () => $connection->flushall())->toThrow(RuntimeException::class);
+
+    $stickiness = new ReflectionProperty(RedisSentinelConnection::class, 'wroteToMaster');
+
+    expect($stickiness->getValue($connection))->toBeFalse();
+});


### PR DESCRIPTION
Closes #59
Closes #39

## Summary

Two flush-semantics bugs in `RedisSentinelConnection`, plus a third discovered during review:

1. `flushall(sync: true)` sent `FLUSHALL ASYNC` — the parameter name and behavior were opposite.
2. `flushdb(async: true)` delegated to the parent, which only recognizes the literal string `'ASYNC'`, so a bool forced a **blocking** flush.
3. (Review finding, probed on the wire with MONITOR) phpredis **6.x inverted the argument semantics**: `Z_PARAM_BOOL` coerces `'ASYNC'` to `true`, and on 6.x `true` selects **SYNC** while `false` selects ASYNC. A naive `'ASYNC'`-string fix would therefore still block on phpredis 6.x — the primary runtime.

## Fix

New `asyncFlushArguments(bool $async)` helper sends the argument that selects ASYNC on the installed extension major (`[false]` on phpredis >= 6.0, `['ASYNC']` on 5.x) and `[]` for a blocking flush:

- `flushall($sync)`: blocking for `true`/`null`, non-blocking for `false`
- `flushdb($async)`: non-blocking for `true`, blocking for `null`/`false`

Parameter names are unchanged (named-argument callers keep working); a legacy `flushdb('ASYNC')` string caller now gets its async intent honored on 6.x instead of being silently flipped to blocking.

**Wire proof** (phpredis 6.3.0, package code path, MONITOR capture):

```
package flushall(sync: false) => FLUSHALL ASYNC
package flushdb(async: true)  => FLUSHDB ASYNC
package flushall()            => FLUSHALL      (blocking)
package flushdb()             => FLUSHDB       (blocking)
```

## Changes

- `src/Connections/RedisSentinelConnection.php` — flush methods + version-aware helper
- `tests/Unit/Connections/RedisSentinelConnectionFlushTest.php` (new) — hermetic partial-mock tests pinning the exact `command()` arguments for every parameter value (runtime-correct async shape) and a non-vacuous stickiness-reset-on-failure test (`wroteToMaster` preset via reflection, as in `ConnectionRetryTest`)
- `README.md` — accurate version-aware wording, keeping the "best-effort, do not rely on the flag" caveat

## Verification

- Full suite: 535 passed (0 failed), Pint + phpstan clean (one now-fixed baseline entry removed, not suppressed)
- Behavior flip `flushall(sync: true)` → blocking is documented in the commit body (semantic-release notes); old docs never advertised reliable ASYNC, so no BREAKING marker