### PR TITLE
fix: fall back to documented retry defaults on null or invalid config values

### DIFF
--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -50,9 +50,9 @@ class RedisSentinelConnector extends PhpRedisConnector
         $this->masterCache = $masterCache;
         $this->config = $config;
 
-        $this->setRetryLimit((int) $config->get('phpredis-sentinel.retry.sentinel.attempts', 5))
-            ->setRetryDelay((int) $config->get('phpredis-sentinel.retry.sentinel.delay', 1000))
-            ->setRetryMessages((array) $config->get('phpredis-sentinel.retry.sentinel.messages', []));
+        $this->setRetryLimit($this->resolveRetryInt($config->get('phpredis-sentinel.retry.sentinel.attempts'), $this->retryLimit))
+            ->setRetryDelay($this->resolveRetryInt($config->get('phpredis-sentinel.retry.sentinel.delay'), $this->retryDelay))
+            ->setRetryMessages($this->resolveRetryMessages($config->get('phpredis-sentinel.retry.sentinel.messages'), $this->retryMessages));
     }
 
     /**
@@ -73,20 +73,17 @@ class RedisSentinelConnector extends PhpRedisConnector
         }
 
         return (new RedisSentinelConnection($connector(), $connector, $config, $readConnector))
-            ->setRetryLimit((int) Arr::get(
-                $config,
-                'retry.redis.attempts',
-                $this->config->get('phpredis-sentinel.retry.redis.attempts', $this->retryLimit)
+            ->setRetryLimit($this->resolveRetryInt(
+                Arr::get($config, 'retry.redis.attempts'),
+                $this->resolveRetryInt($this->config->get('phpredis-sentinel.retry.redis.attempts'), $this->retryLimit)
             ))
-            ->setRetryDelay((int) Arr::get(
-                $config,
-                'retry.redis.delay',
-                $this->config->get('phpredis-sentinel.retry.redis.delay', $this->retryDelay)
+            ->setRetryDelay($this->resolveRetryInt(
+                Arr::get($config, 'retry.redis.delay'),
+                $this->resolveRetryInt($this->config->get('phpredis-sentinel.retry.redis.delay'), $this->retryDelay)
             ))
-            ->setRetryMessages((array) Arr::get(
-                $config,
-                'retry.redis.messages',
-                $this->config->get('phpredis-sentinel.retry.redis.messages', $this->retryMessages)
+            ->setRetryMessages($this->resolveRetryMessages(
+                Arr::get($config, 'retry.redis.messages'),
+                $this->resolveRetryMessages($this->config->get('phpredis-sentinel.retry.redis.messages'), $this->retryMessages)
             ));
     }
 
@@ -291,6 +288,10 @@ class RedisSentinelConnector extends PhpRedisConnector
     /**
      * Connect to the configured Redis Sentinel instance.
      *
+     * When no Sentinel host is reachable the reported cause is the LAST failure
+     * observed across the node loop (most recent, most specific). Earlier failures
+     * are not preserved — the ConfigurationException carries only this one.
+     *
      * @throws ConfigurationException
      */
     protected function connectToSentinel(array $config): RedisSentinel
@@ -461,6 +462,36 @@ class RedisSentinelConnector extends PhpRedisConnector
         $config['options'] = array_merge($options, $configOptions);
 
         return $config;
+    }
+
+    /**
+     * Resolve an integer retry setting, falling back when the configured value is
+     * null (explicit) or otherwise not a usable non-negative integer, instead of
+     * casting null/bool to 0. Numeric strings are accepted so env()-wrapped
+     * published configs keep working.
+     */
+    private function resolveRetryInt(mixed $value, int $default): int
+    {
+        $int = filter_var($value, FILTER_VALIDATE_INT);
+
+        return $int !== false && $int >= 0 ? $int : $default;
+    }
+
+    /**
+     * Resolve a retry message list, falling back when the configured value is
+     * null or not an array. An explicit empty array stays valid: it means
+     * "never retry on message match".
+     *
+     * @param  array<int, string>  $default
+     * @return array<int, string>
+     */
+    private function resolveRetryMessages(mixed $value, array $default): array
+    {
+        if ($value === null || ! is_array($value)) {
+            return $default;
+        }
+
+        return array_values(array_filter($value, 'is_string'));
     }
 
     private function needParamsAsArray(): bool

--- a/tests/Unit/Connectors/RetryConfigResolutionTest.php
+++ b/tests/Unit/Connectors/RetryConfigResolutionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+
+function resolvingConnector(): RedisSentinelConnector
+{
+    return new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            return Mockery::mock(Redis::class);
+        }
+    };
+}
+
+function retrySettings(RedisSentinelConnection $connection): array
+{
+    return [
+        'limit' => (new ReflectionProperty($connection, 'retryLimit'))->getValue($connection),
+        'delay' => (new ReflectionProperty($connection, 'retryDelay'))->getValue($connection),
+        'messages' => (new ReflectionProperty($connection, 'retryMessages'))->getValue($connection),
+    ];
+}
+
+test('explicit null in retry config falls back to documented defaults', function () {
+    config([
+        'phpredis-sentinel.retry.redis.attempts' => 5,
+        'phpredis-sentinel.retry.redis.delay' => 1000,
+    ]);
+
+    $connection = resolvingConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+        'retry' => ['redis' => ['attempts' => null, 'delay' => null, 'messages' => null]],
+    ], []);
+
+    expect(retrySettings($connection))->toBe([
+        'limit' => 5,
+        'delay' => 1000,
+        'messages' => config('phpredis-sentinel.retry.redis.messages'),
+    ]);
+});
+
+test('explicit zeros and empty message list are respected', function () {
+    $connection = resolvingConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+        'retry' => ['redis' => ['attempts' => 0, 'delay' => 0, 'messages' => []]],
+    ], []);
+
+    expect(retrySettings($connection))->toBe([
+        'limit' => 0,
+        'delay' => 0,
+        'messages' => [],
+    ]);
+});
+
+test('invalid scalars in retry config fall back to defaults', function () {
+    config([
+        'phpredis-sentinel.retry.redis.attempts' => 5,
+        'phpredis-sentinel.retry.redis.delay' => 1000,
+    ]);
+
+    $connection = resolvingConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+        'retry' => ['redis' => ['attempts' => 'many', 'delay' => -50, 'messages' => 'socket']],
+    ], []);
+
+    expect(retrySettings($connection))->toBe([
+        'limit' => 5,
+        'delay' => 1000,
+        'messages' => config('phpredis-sentinel.retry.redis.messages'),
+    ]);
+});
+
+test('a per-connection null falls through to a distinct global value before the default', function () {
+    config([
+        'phpredis-sentinel.retry.redis.attempts' => 7,
+    ]);
+
+    $connection = resolvingConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+        'retry' => ['redis' => ['attempts' => null]],
+    ], []);
+
+    expect((new ReflectionProperty($connection, 'retryLimit'))->getValue($connection))->toBe(7);
+});
+
+test('global sentinel retry config falls back to connector defaults on null or invalid values', function () {
+    config([
+        'phpredis-sentinel.retry.sentinel.attempts' => null,
+        'phpredis-sentinel.retry.sentinel.delay' => 'soon',
+        'phpredis-sentinel.retry.sentinel.messages' => null,
+    ]);
+
+    $connector = resolvingConnector();
+
+    expect((new ReflectionProperty($connector, 'retryLimit'))->getValue($connector))->toBe(5)
+        ->and((new ReflectionProperty($connector, 'retryDelay'))->getValue($connector))->toBe(1000)
+        ->and((new ReflectionProperty($connector, 'retryMessages'))->getValue($connector))->toBe([]);
+});


### PR DESCRIPTION
Closes #36

## Summary

In `RedisSentinelConnector`, `(int)`/`(array)` casts turned an **explicit `null`** in retry config into `0`/`[]` instead of falling back to the documented defaults: `'attempts' => null` silently disabled retries.

## Changes

- Two tolerant resolvers replace the casts at all six config-resolution sites (sentinel + redis, constructor + per-connection):
  - `resolveRetryInt`: `null`/bool/non-numeric/negative → default; numeric strings accepted (`env()`-wrapped published configs keep working — review finding); explicit `0` stays a valid value
  - `resolveRetryMessages`: `null`/non-array → default; explicit `[]` stays a valid "never retry on message match"; non-string entries filtered
  - The 3-level fallback chain is preserved exactly (per-connection → global → trait defaults) and now pinned by a test with a **distinguishing** global value (attempts `7` ≠ default `5`)
- `$lastException` semantics **decided and documented**: last-write-wins across the Sentinel node loop (most recent, most specific cause) — behavior unchanged, PHPDoc added to `connectToSentinel()`.

## Verification

- Red-proof: with the fix stashed, explicit-null test failed `limit 0 / delay 0 / messages []` vs expected defaults — exactly the reported bug
- Tests: null→defaults, explicit zeros/empty list respected, invalid scalars → defaults, per-connection null → global fallthrough, global sentinel null/invalid → connector defaults
- Full suite: 543 passed (0 failed), Pint + phpstan clean
- `fix:` → patch (the cast contradicted the documented defaults; not BREAKING)