### PR TITLE
feat: opt-in error_log notice when swallowed log failures drop telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ return [
 
     'log' => [
         'channel' => null, // Use Laravel's default log channel
+        'notify_swallowed' => false, // error_log() notice (once per consuming class) when logging failures are swallowed
     ],
 
     'retry' => [
@@ -243,6 +244,11 @@ return [
     ],
 ];
 ```
+
+- `log.notify_swallowed` (default `false`): when the configured log channel throws, the
+  package swallows the failure so retries never break. Set `REDIS_SENTINEL_LOG_NOTIFY_SWALLOWED=true`
+  to emit an `error_log()` notice when telemetry is being dropped this way — once per
+  consuming class, so a process sees at most a handful of notices.
 
 ### Data connection defaults (v1.3+)
 

--- a/config/phpredis-sentinel.php
+++ b/config/phpredis-sentinel.php
@@ -11,6 +11,9 @@ return [
 
     'log' => [
         'channel' => env('REDIS_SENTINEL_LOG_CHANNEL', env('LOG_CHANNEL')),
+        // Once per consuming class, error_log() a notice when a logging failure is
+        // swallowed (opt-in: retry/failover telemetry is being lost otherwise).
+        'notify_swallowed' => env('REDIS_SENTINEL_LOG_NOTIFY_SWALLOWED', false),
     ],
     'commands' => [
         'events' => [

--- a/src/Concerns/Loggable.php
+++ b/src/Concerns/Loggable.php
@@ -10,6 +10,12 @@ trait Loggable
     protected ?string $logPrefix = null;
 
     /**
+     * Static properties on traits are copied into each consuming class, so this
+     * flag is once per consuming class per process, not once globally.
+     */
+    private static bool $swallowedLogNotified = false;
+
+    /**
      * Log a message with context.
      *
      * If 'phpredis-sentinel.log.channel' is null, Log::channel(null) returns
@@ -29,9 +35,18 @@ trait Loggable
                 $this->getLogPrefix(),
                 $message
             ), $context);
-        } catch (Throwable) {
+        } catch (Throwable $e) {
             // Logging must never break the retry path (e.g. a Redis-backed log
             // channel failing while Redis itself is down).
+            if (! self::$swallowedLogNotified && config('phpredis-sentinel.log.notify_swallowed', false)) {
+                self::$swallowedLogNotified = true;
+
+                error_log(sprintf(
+                    '[laravel-redis-sentinel] logging is failing (%s); retry/failover telemetry is being dropped. Original message: %s',
+                    $e->getMessage(),
+                    $message
+                ));
+            }
         }
     }
 

--- a/tests/Unit/Concerns/LoggableSwallowTest.php
+++ b/tests/Unit/Concerns/LoggableSwallowTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Tests\Unit\Concerns;
+
+use Goopil\LaravelRedisSentinel\Concerns\Loggable;
+use Goopil\LaravelRedisSentinel\Concerns\Retryable;
+use Illuminate\Support\Facades\Log;
+use ReflectionProperty;
+use RuntimeException;
+
+beforeEach(function () {
+    $property = new ReflectionProperty(LoggableTestObject::class, 'swallowedLogNotified');
+    $property->setAccessible(true);
+    $property->setValue(null, false);
+});
+
+test('a swallowed logging failure emits exactly one error_log notice when enabled', function () {
+    $originalErrorLog = ini_get('error_log');
+    $logFile = tempnam(sys_get_temp_dir(), 'log');
+    ini_set('error_log', $logFile);
+
+    try {
+        config([
+            'phpredis-sentinel.log.channel' => 'stack',
+            'phpredis-sentinel.log.notify_swallowed' => true,
+        ]);
+
+        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+
+        $obj = new LoggableTestObject;
+        $obj->testLog('test message');
+        $obj->testLog('test message');
+
+        $contents = (string) file_get_contents($logFile);
+
+        expect(substr_count($contents, '[laravel-redis-sentinel] logging is failing'))->toBe(1)
+            ->and($contents)->toContain('log backend down')
+            ->and($contents)->toContain('test message');
+    } finally {
+        ini_set('error_log', $originalErrorLog);
+        @unlink($logFile);
+    }
+});
+
+test('swallowed logging failures stay silent when the notice is disabled', function () {
+    $originalErrorLog = ini_get('error_log');
+    $logFile = tempnam(sys_get_temp_dir(), 'log');
+    ini_set('error_log', $logFile);
+
+    try {
+        config([
+            'phpredis-sentinel.log.channel' => 'stack',
+            'phpredis-sentinel.log.notify_swallowed' => false,
+        ]);
+
+        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+
+        $obj = new LoggableTestObject;
+        $obj->testLog('test message');
+        $obj->testLog('test message');
+
+        expect(file_get_contents($logFile))->toBe('');
+    } finally {
+        ini_set('error_log', $originalErrorLog);
+        @unlink($logFile);
+    }
+});
+
+test('a logging outage cannot break the retry loop', function () {
+    config([
+        'phpredis-sentinel.log.channel' => 'stack',
+        // Exercise the swallowed-failure notice path inside the retry loop as well:
+        // the notice itself must never break the loop either.
+        'phpredis-sentinel.log.notify_swallowed' => true,
+    ]);
+
+    Log::shouldReceive('channel')->andThrow(new RuntimeException('log backend down'));
+
+    $obj = new class
+    {
+        use Loggable;
+        use Retryable;
+
+        public int $callCount = 0;
+
+        public function run(): string
+        {
+            return $this->retryOnFailure(function () {
+                $this->callCount++;
+                $this->log('attempt '.$this->callCount);
+
+                if ($this->callCount <= 2) {
+                    throw new RuntimeException('connection lost');
+                }
+
+                return 'success';
+            });
+        }
+
+        protected function sleepWithBackoff(int $attempt): void {}
+    };
+
+    $obj->setRetryMessages(['connection lost']);
+
+    expect($obj->run())->toBe('success')
+        ->and($obj->callCount)->toBe(3);
+});


### PR DESCRIPTION
Closes #40

## Summary

`Loggable::log()` swallows logging failures so a broken log channel can never break the retry loop (correct trade-off) — but the swallow was completely silent: operators lost retry/failover telemetry with no signal.

## Changes

- Opt-in, once-per-consuming-class `error_log()` notice emitted inside the swallow path: `[laravel-redis-sentinel] logging is failing (<reason>); retry/failover telemetry is being dropped. Original message: <msg>`. Gated by new config `log.notify_swallowed` (env `REDIS_SENTINEL_LOG_NOTIFY_SWALLOWED`, default `false`).
- Swallow semantics unchanged — the notice itself is non-throwing on the tested paths and the retry loop stays immune.
- Tests: notice emitted exactly once across 2 failures (content checked), silent when disabled, and the retry-loop survival test now runs **with the notice path enabled** so the riskiest branch is proven loop-safe.
- README documents the key and the once-per-consuming-class semantics (a process sees at most a handful of notices).

## Verification

- Full suite: 541 passed (0 failed), Pint + phpstan clean
- `feat:` → minor (new config surface, default off, non-breaking)