### PR TITLE
docs: document the sequential-runtime contract for shared connection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ The package is compatible with Laravel Octane and supports long-lived processes:
 The connection mutates shared per-command state (master/replica client swap, sticky flag), so **concurrent
 coroutines sharing one worker are not fully supported for R/W splitting**: interleaving can flip routing
 mid-request, and the retry backoff blocks the whole worker, not just the coroutine that hit the failure.
+The manager shares the same caveat: `RedisSentinelManager` temporarily swaps its internal `$driver` property
+while resolving a connection — another piece of transient shared state that assumes sequential resolution.
 
 - **Safe**: sequential runtimes — FPM, FrankenPHP worker mode, RoadRunner, Swoole with a single in-flight
   request per worker.
@@ -526,6 +528,9 @@ mid-request, and the retry backoff blocks the whole worker, not just the corouti
 
 If you rely on concurrent coroutines, disable `read_only_replicas` (everything routes to the master, no client
 swap) or keep R/W splitting on sequential workers.
+
+The sequential contract is pinned by the hermetic `InterleavedRoutingTest` (unit) — coroutine-level races on the
+shared client swap are explicitly out of scope without ext-swoole in CI.
 
 ### No Configuration Needed
 


### PR DESCRIPTION
Closes #66

## Summary

Design decision (option 3 of the issue, agreed): document the **sequential-runtime contract** for the package's shared connection state rather than re-architecting the routing.

## What was already in place

The README already documented most of the contract (client swap per command, sticky flag + request-boundary resets, retry backoff blocking the whole worker, safe/not-safe runtime lists, the `read_only_replicas=false` workaround). This PR audits those claims against the issue's list of shared-state mutations and adds what was missing:

- the `RedisSentinelManager` transient `$driver` swap during connection resolution (same shared-state class, was undocumented);
- a reference to the hermetic `InterleavedRoutingTest` as the contract-pinning test, with the explicit scope note: coroutine-level races on the shared client swap are out of scope without ext-swoole in CI.

## Decision rationale

The package's primary consumers (Horizon/K8s workers, FPM) are sequential runtimes; the coroutine options (per-coroutine context storage, or removing the client swap with upstream-friendly overrides) are high-effort, high-regression-risk re-architectures without a demonstrated user need. The options remain viable future work if a concrete coroutine use case appears — the interleaving test serves as the demonstration gate.

## Verification

- README only (+5 lines); no runtime behavior change; `docs:` → no release