### PR TITLE
fix: isolate Sentinel node timeouts from the data connection timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ return [
 ### Data connection defaults (v1.3+)
 
 - `timeout` for the data connection defaults to **5 seconds** and is no longer derived from `sentinel.timeout`.
+- Sentinel node timeouts are isolated from the data connection: `connectTimeout` comes from
+  `sentinel.timeout` only (default `1` s) and Sentinel `readTimeout` from `sentinel.read_timeout`
+  only (default `60` s). Raising the data `timeout`/`read_timeout` no longer affects Sentinel nodes.
 - The data client uses strictly `password`; `sentinel.password` only authenticates against Sentinel nodes.
 - `retry.redis.messages` can be overridden **per connection** (`retry.redis.messages` inside the connection config), like `attempts`/`delay`. See the [Retry contract](#retry-contract) for the at-least-once implications.
 - Resolved master/replica addresses are cached with a TTL: `phpredis-sentinel.node_cache.ttl` (seconds, default `15`; `0`
@@ -712,9 +715,10 @@ your own Redis topology, workload, and deployment model.
   is re-executed after reconnection. Only use idempotent operations inside, or handle duplicates in your callback.
 - **Scan-family commands reset their cursor** on retry after a reconnection, so iteration restarts on the new node (SCAN
   semantics allow duplicates).
-- **`read_timeout` defaults to 60 seconds** (both the Redis client and the Sentinel client): a blocking command on a half-open
-  socket now fails after 60s instead of hanging the worker forever. Set `read_timeout: 0` for unbounded blocking reads, and
-  always keep it above your longest blocking command (`BLPOP`, `WAIT`, ...).
+- **`read_timeout` defaults to 60 seconds** for the data Redis client (a blocking command on a half-open
+  socket now fails after 60s instead of hanging the worker forever). Set `read_timeout: 0` for unbounded blocking reads, and
+  always keep it above your longest blocking command (`BLPOP`, `WAIT`, ...). The Sentinel node read timeout is
+  configured separately via `sentinel.read_timeout` (default `60` s).
 - **`flushdb($async)` / `flushall($sync)` flush semantics are normalized**: `flushdb(async: true)` and `flushall(sync: false)`
   request a non-blocking flush. The package sends the argument that selects ASYNC on the installed phpredis major (`false` on
   phpredis 6.x, the literal `'ASYNC'` on 5.x); any other value (including the defaults) performs a blocking flush.

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -320,10 +320,10 @@ class RedisSentinelConnector extends PhpRedisConnector
             $options = [
                 'host' => $host,
                 'port' => $port,
-                'connectTimeout' => $config['sentinel']['timeout'] ?? $config['timeout'] ?? 1.0,
+                'connectTimeout' => $config['sentinel']['timeout'] ?? 1.0,
                 'persistent' => $config['sentinel']['persistent'] ?? $config['persistent'] ?? null,
                 'retryInterval' => $config['sentinel']['retry_interval'] ?? $config['retry_interval'] ?? 0,
-                'readTimeout' => $config['sentinel']['read_timeout'] ?? $config['read_timeout'] ?? 60.0,
+                'readTimeout' => $config['sentinel']['read_timeout'] ?? 60.0,
             ];
 
             if (($password = $config['sentinel']['password'] ?? $config['password'] ?? '') !== '') {

--- a/tests/Unit/Connectors/RedisSentinelConnectorTest.php
+++ b/tests/Unit/Connectors/RedisSentinelConnectorTest.php
@@ -308,3 +308,89 @@ test('createSentinel defaults Sentinel client readTimeout to 60', function () {
 
     expect($connector->capturedOptions['readTimeout'])->toBe(60.0);
 });
+
+test('Sentinel connectTimeout is pinned to its own sentinel.timeout and ignores the data timeout', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public ?array $capturedOptions = null;
+
+        protected function createSentinelInstance(array $options): RedisSentinel
+        {
+            $this->capturedOptions = $options;
+
+            return parent::createSentinelInstance($options);
+        }
+    };
+
+    config(['database.redis.my-sentinel' => [
+        'sentinel' => [
+            'host' => CONNECTOR_TEST_HOST,
+            'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+            'service' => 'master',
+            'password' => env('REDIS_PASSWORD', 'test'),
+        ],
+        'timeout' => 5.0,
+    ]]);
+
+    $connector->createSentinel('my-sentinel');
+
+    expect($connector->capturedOptions['connectTimeout'])->toBe(1.0);
+
+    config(['database.redis.my-sentinel' => [
+        'sentinel' => [
+            'host' => CONNECTOR_TEST_HOST,
+            'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+            'service' => 'master',
+            'password' => env('REDIS_PASSWORD', 'test'),
+            'timeout' => 1.5,
+        ],
+        'timeout' => 5.0,
+    ]]);
+
+    $connector->createSentinel('my-sentinel');
+
+    expect($connector->capturedOptions['connectTimeout'])->toBe(1.5);
+});
+
+test('Sentinel readTimeout is pinned to its own sentinel.read_timeout and ignores the data read_timeout', function () {
+    $connector = new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public ?array $capturedOptions = null;
+
+        protected function createSentinelInstance(array $options): RedisSentinel
+        {
+            $this->capturedOptions = $options;
+
+            return parent::createSentinelInstance($options);
+        }
+    };
+
+    config(['database.redis.my-sentinel' => [
+        'sentinel' => [
+            'host' => CONNECTOR_TEST_HOST,
+            'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+            'service' => 'master',
+            'password' => env('REDIS_PASSWORD', 'test'),
+        ],
+        'read_timeout' => 5,
+    ]]);
+
+    $connector->createSentinel('my-sentinel');
+
+    expect($connector->capturedOptions['readTimeout'])->toBe(60.0);
+
+    config(['database.redis.my-sentinel' => [
+        'sentinel' => [
+            'host' => CONNECTOR_TEST_HOST,
+            'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+            'service' => 'master',
+            'password' => env('REDIS_PASSWORD', 'test'),
+            'read_timeout' => 2,
+        ],
+        'read_timeout' => 5,
+    ]]);
+
+    $connector->createSentinel('my-sentinel');
+
+    expect($connector->capturedOptions['readTimeout'])->toBe(2);
+});


### PR DESCRIPTION
Closes #42
Closes #38

## Summary

The Sentinel options derived both node timeouts from the data connection config:

- `connectTimeout` = `sentinel.timeout ?? timeout ?? 1.0`
- `readTimeout` = `sentinel.read_timeout ?? read_timeout ?? 60.0`

A user who only raised the data `timeout` silently got a multi-second per-Sentinel-node connect timeout — contradicting the timeout-decoupling narrative. Decision (agreed): **pin each Sentinel timeout to its own key**.

## Changes

- `connectTimeout` = `sentinel.timeout ?? 1.0` — the pinned default **stays at 1 s** (a deliberate value chosen in f7fc6e2: 0.2 s was too aggressive across network segments; the review caught that taking the issue text's 0.2 would have silently reverted it)
- `readTimeout` = `sentinel.read_timeout ?? 60.0`
- `persistent`/`retryInterval` keep their data fallbacks (out of scope); data client options untouched
- README: new isolation bullet under "Data connection defaults", and the `read_timeout` guidance corrected — it governs the **data client only**; the Sentinel node read timeout is `sentinel.read_timeout` (the old "both the Redis client and the Sentinel client" wording became false with this change)

## Verification

- 2 new pinning tests (data-only → defaults; `sentinel.*` set → wins) through the real `createSentinel → connectToSentinel` path
- Full suite: 552 passed (0 failed), Pint + phpstan clean
- Behavior change documented in the commit body for users who relied on the data-timeout fallback