### PR TITLE
fix: make event dispatch best-effort so observability cannot break retries

### DIFF
--- a/src/Concerns/EmitsWorkerEvents.php
+++ b/src/Concerns/EmitsWorkerEvents.php
@@ -2,30 +2,19 @@
 
 namespace Goopil\LaravelRedisSentinel\Concerns;
 
-use Throwable;
-
 trait EmitsWorkerEvents
 {
     protected function emitSuccessEvent(object $event): void
     {
         // env() keeps "1" as a string, so parse the value instead of comparing to true.
         if (filter_var(config('phpredis-sentinel.commands.events.emit_success'), FILTER_VALIDATE_BOOLEAN)) {
-            // Kubernetes probes must keep their exit code even if a listener throws.
-            try {
-                event($event);
-            } catch (Throwable $e) {
-                report($e);
-            }
+            $this->dispatchSafely($event);
         }
     }
 
     protected function emitFailureEvent(object $event): void
     {
         // Kubernetes probes must keep their exit code even if a listener throws.
-        try {
-            event($event);
-        } catch (Throwable $e) {
-            report($e);
-        }
+        $this->dispatchSafely($event);
     }
 }

--- a/src/Concerns/Loggable.php
+++ b/src/Concerns/Loggable.php
@@ -42,11 +42,42 @@ trait Loggable
                 self::$swallowedLogNotified = true;
 
                 error_log(sprintf(
-                    '[laravel-redis-sentinel] logging is failing (%s); retry/failover telemetry is being dropped. Original message: %s',
+                    '[laravel-redis-sentinel] logging is failing (%s); retry/failover telemetry may be dropped. Original message: %s',
                     $e->getMessage(),
                     $message
                 ));
             }
+
+            // One retry against a channel that does not depend on the failing
+            // backend, unless stderr itself is the channel that just failed.
+            try {
+                if (config('phpredis-sentinel.log.channel') !== 'stderr') {
+                    Log::channel('stderr')->{$level}(sprintf('[%s] %s', $this->getLogPrefix(), $message), $context);
+                }
+            } catch (Throwable) {
+                // Nothing left to try — the swallow contract stands.
+            }
+        }
+    }
+
+    /**
+     * Dispatch an event without ever breaking the caller: a throwing user listener
+     * must not abort a retry loop or a failover path. Failures are logged (swallow
+     * contract applies) and the flow continues.
+     */
+    protected function dispatchSafely(object $event): void
+    {
+        try {
+            event($event);
+        } catch (Throwable $e) {
+            // A throwing listener is a real bug: feed the exception handler as well,
+            // best-effort, then warn on the swallow-safe channel.
+            try {
+                report($e);
+            } catch (Throwable) {
+            }
+
+            $this->log('event listener failed', ['event' => get_class($event), 'error' => $e->getMessage()], 'error');
         }
     }
 

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -389,7 +389,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 }
             },
             onFail: function ($exception, $attempts) use ($name, $isReadOnly, &$usedClient, $onFailExtra) {
-                RedisSentinelConnectionFailed::dispatch($this, $exception, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionFailed($this, $exception, $name, $attempts));
 
                 $onFailExtra?->__invoke();
 
@@ -416,7 +416,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 ], 'error');
             },
             onReconnect: function ($attempts) use ($name) {
-                RedisSentinelConnectionReconnected::dispatch($this, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionReconnected($this, $name, $attempts));
 
                 $this->log($name.' - reconnected', [
                     'method' => $name,
@@ -425,7 +425,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 ]);
             },
             onMaxFail: function ($exception, $attempts) use ($name) {
-                RedisSentinelConnectionMaxRetryFailed::dispatch($this, $exception, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionMaxRetryFailed($this, $exception, $name, $attempts));
 
                 $this->log($name.' - max fail', [
                     'method' => $name,

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -269,7 +269,7 @@ class RedisSentinelConnector extends PhpRedisConnector
 
             if (empty($replicas)) {
                 $this->log('No healthy replica, reads fall back to the master', ['service' => $service, 'replicas' => $slaves], 'warning');
-                RedisSentinelReplicaFallback::dispatch($service, $slaves);
+                $this->dispatchSafely(new RedisSentinelReplicaFallback($service, $slaves));
 
                 return $this->getMasterAddress($config, $refresh);
             }
@@ -515,7 +515,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelFail(string $service, string $method): Closure
     {
         return function ($exception, $attempts) use ($service, $method) {
-            RedisSentinelMasterFailed::dispatch($service, $exception, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterFailed($service, $exception, $method, $attempts));
 
             $this->log($method.' - fail', [
                 'method' => $method,
@@ -529,7 +529,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelReconnect(string $service, string $method): Closure
     {
         return function ($attempts) use ($service, $method) {
-            RedisSentinelMasterReconnected::dispatch($service, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterReconnected($service, $method, $attempts));
 
             $this->log($method.' - reconnected', [
                 'method' => $method,
@@ -542,7 +542,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelMaxFail(string $service, string $method): Closure
     {
         return function ($exception, $attempts) use ($service, $method) {
-            RedisSentinelMasterMaxRetryFailed::dispatch($service, $exception, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterMaxRetryFailed($service, $exception, $method, $attempts));
 
             $this->log($method.' - max fail', [
                 'method' => $method,

--- a/tests/Unit/Concerns/LoggableSwallowTest.php
+++ b/tests/Unit/Concerns/LoggableSwallowTest.php
@@ -5,6 +5,7 @@ namespace Goopil\LaravelRedisSentinel\Tests\Unit\Concerns;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
 use Goopil\LaravelRedisSentinel\Concerns\Retryable;
 use Illuminate\Support\Facades\Log;
+use Mockery;
 use ReflectionProperty;
 use RuntimeException;
 
@@ -25,7 +26,8 @@ test('a swallowed logging failure emits exactly one error_log notice when enable
             'phpredis-sentinel.log.notify_swallowed' => true,
         ]);
 
-        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stack')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stderr')->twice()->andThrow(new RuntimeException('stderr backend down'));
 
         $obj = new LoggableTestObject;
         $obj->testLog('test message');
@@ -53,7 +55,8 @@ test('swallowed logging failures stay silent when the notice is disabled', funct
             'phpredis-sentinel.log.notify_swallowed' => false,
         ]);
 
-        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stack')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stderr')->twice()->andThrow(new RuntimeException('stderr backend down'));
 
         $obj = new LoggableTestObject;
         $obj->testLog('test message');
@@ -74,7 +77,50 @@ test('a logging outage cannot break the retry loop', function () {
         'phpredis-sentinel.log.notify_swallowed' => true,
     ]);
 
-    Log::shouldReceive('channel')->andThrow(new RuntimeException('log backend down'));
+    Log::shouldReceive('channel')->with('stack')->andThrow(new RuntimeException('log backend down'));
+
+    // When the configured channel is down, the safe-channel retry must deliver
+    // the entry to the 'stderr' channel instead of dropping it.
+    $stderr = Mockery::mock();
+    $stderr->shouldReceive('info')->atLeast()->once()->with(Mockery::pattern('/attempt/'), []);
+
+    Log::shouldReceive('channel')->with('stderr')->andReturn($stderr);
+
+    $obj = new class
+    {
+        use Loggable;
+        use Retryable;
+
+        public int $callCount = 0;
+
+        public function run(): string
+        {
+            return $this->retryOnFailure(function () {
+                $this->callCount++;
+                $this->log('attempt '.$this->callCount);
+
+                if ($this->callCount <= 2) {
+                    throw new RuntimeException('connection lost');
+                }
+
+                return 'success';
+            });
+        }
+
+        protected function sleepWithBackoff(int $attempt): void {}
+    };
+
+    $obj->setRetryMessages(['connection lost']);
+
+    expect($obj->run())->toBe('success')
+        ->and($obj->callCount)->toBe(3);
+});
+
+test('even the stderr fallback failing cannot break the retry loop', function () {
+    config(['phpredis-sentinel.log.channel' => 'stack']);
+
+    Log::shouldReceive('channel')->with('stack')->andThrow(new RuntimeException('log backend down'));
+    Log::shouldReceive('channel')->with('stderr')->andThrow(new RuntimeException('stderr down too'));
 
     $obj = new class
     {

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -42,6 +42,29 @@ test('a dynamic command that succeeds after one failure returns its result', fun
         ->and(Event::assertDispatchedTimes(RedisSentinelConnectionFailed::class, 1))->toBeNull();
 });
 
+test('a throwing listener on the connection fail event does not abort the retry loop', function () {
+    $listenerInvoked = false;
+    Event::listen(RedisSentinelConnectionFailed::class, function () use (&$listenerInvoked): void {
+        $listenerInvoked = true;
+
+        throw new RuntimeException('listener down');
+    });
+
+    $client = Mockery::mock(Redis::class);
+    $client->expects('hset')->twice()->andReturnUsing(
+        fn () => throw new RedisException('broken pipe'),
+        fn () => 1,
+    );
+
+    $connection = new RedisSentinelConnection($client, fn () => $client, []);
+    $connection->setRetryLimit(1);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(['broken pipe']);
+
+    expect($connection->hset('key', 'field', 'value'))->toBe(1)
+        ->and($listenerInvoked)->toBeTrue();
+});
+
 test('a failed sticky read refreshes the master, not the replica', function () {
     Event::fake();
 

--- a/tests/Unit/Events/DispatchSafetyTest.php
+++ b/tests/Unit/Events/DispatchSafetyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Tests\Unit\Events;
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelReplicaFallback;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Redis;
+use RedisSentinel;
+use RuntimeException;
+
+const HOST_1 = '127.0.0.1';
+const HOST_2 = '127.0.0.2';
+
+test('a throwing listener on the replica fallback event does not break the master fallback', function () {
+    $listenerInvoked = false;
+    Event::listen(RedisSentinelReplicaFallback::class, function () use (&$listenerInvoked): void {
+        $listenerInvoked = true;
+
+        throw new RuntimeException('listener down');
+    });
+
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave,disconnected'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1)
+        ->and($listenerInvoked)->toBeTrue();
+});
+
+test('a failing exception handler does not break the dispatch guard either', function () {
+    Event::listen(RedisSentinelReplicaFallback::class, function (): void {
+        throw new RuntimeException('listener down');
+    });
+
+    $previousHandler = app()->instance(
+        Illuminate\Contracts\Debug\ExceptionHandler::class,
+        Mockery::mock(Illuminate\Contracts\Debug\ExceptionHandler::class, function ($mock): void {
+            $mock->shouldReceive('report')->andThrow(new RuntimeException('handler down too'));
+        })
+    );
+
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave,disconnected'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1);
+
+    app()->instance(Illuminate\Contracts\Debug\ExceptionHandler::class, $previousHandler);
+});


### PR DESCRIPTION
Closes #58

## Summary

Event dispatches ran unprotected inside retry/failover callbacks — a throwing user listener aborted the retry loop: observability destroyed the resilience it observed.

## Changes

- New `Loggable::dispatchSafely()`: `event()` wrapped in try/catch; on failure it feeds the exception handler (`report()`, best-effort) and logs at `error` through the swallow-safe channel — then the flow continues. All 9 package dispatch sites converted (connector ×4, connection ×3, Horizon worker events ×2).
- `Loggable::log()` swallow path now retries **once** against the `stderr` channel (unless `stderr` itself is the failing channel) before giving up — completing the #40 observability ladder: notice → safe-channel retry → drop.
- The once-per-class `error_log` notice wording now says telemetry "may be dropped" (the stderr retry can still deliver the entry).

## Verification

- New tests: throwing listener on `RedisSentinelReplicaFallback` → the master fallback still returns (hermetic, forces the no-healthy-replica path so the dispatch really fires); throwing listener on `ConnectionFailed` → the retry loop survives and completes (`hset` twice proves both attempts run); the retry-outage test now asserts `stderr` receives the entry at the right level.
- Full suite: 552 passed (0 failed), Pint + phpstan clean
- `fix:` → patch