### PR TITLE
feat: isolate connection state per execution context for coroutine safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Retry delays are overridden to 1ms in `TestCase` for speed.
 ## Architecture
 
 - `RedisSentinelManager` extends Laravel's `RedisManager`; registers the `phpredis-sentinel` driver via `RedisSentinelConnector`.
-- `RedisSentinelConnection` extends `PhpRedisConnection` and implements read/write splitting by mutating `$this->client` between master and replica clients.
+- `RedisSentinelConnection` extends `PhpRedisConnection` and implements read/write splitting with per-execution-context state (`src/Context/`): each coroutine (Swoole/OpenSwoole) or worker process owns its master/replica clients, stickiness and transaction level. The per-command swap still mutates `$this->client` but targets context clients and restores the previous value; split mode creates per-context clients lazily, non-split keeps the shared constructor client.
 - `NodeAddressCache` is an in-memory singleton — not shared across workers/processes, but persists between requests in Octane. Stale cache can mask failovers in long-running processes.
 - `RedisSentinelServiceProvider` overrides Laravel's global `redis`/`redis.connection` bindings by default (`override_laravel_redis: true`). Disabling this breaks Horizon compatibility — Horizon resolves Redis through the global binding.
 - Read-only command allowlist is hardcoded in `RedisSentinelConnection::READ_ONLY_COMMAND` (not configurable).

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Important limitations when `REDIS_SENTINEL_OVERRIDE_LARAVEL_REDIS=false`:
 
 For most applications, keep the override enabled. Disable it only for advanced mixed setups where Laravel's native Redis manager must remain global and Sentinel is used through explicitly configured package integrations.
 
+Resolving a `phpredis-sentinel` connection when the package's connector creator is not registered throws a `ConfigurationException` instead of failing with a fatal PHP error.
+
 ### Retry Strategy
 
 The package uses **exponential backoff with jitter** to avoid thundering herd:
@@ -380,7 +382,10 @@ Cache::put('user:123', 'John');  // Write to master, enables sticky mode
 $name = Cache::get('user:123');   // Read from master → guaranteed fresh
 ```
 
-The sticky mode **automatically resets** between requests in Octane/Horizon.
+Stickiness lives in per-execution-context state: under concurrent runtimes (Swoole/OpenSwoole) each request
+coroutine gets its own flag, so it is structurally scoped to the request; on sequential runtimes (FPM, RoadRunner,
+CLI workers) the context is the long-lived worker process, which is why the package additionally resets stickiness
+on each Octane lifecycle event and queue `JobProcessing` event as belt-and-suspenders.
 
 ### Replica-Safe Commands
 
@@ -519,21 +524,42 @@ The package is compatible with Laravel Octane and supports long-lived processes:
 
 ### Coroutine runtimes (Swoole) and R/W splitting
 
-The connection mutates shared per-command state (master/replica client swap, sticky flag), so **concurrent
-coroutines sharing one worker are not fully supported for R/W splitting**: interleaving can flip routing
-mid-request, and the retry backoff blocks the whole worker, not just the coroutine that hit the failure.
-The manager shares the same caveat: `RedisSentinelManager` temporarily swaps its internal `$driver` property
-while resolving a connection — another piece of transient shared state that assumes sequential resolution.
+Connection state (master/replica clients, stickiness, transaction level) lives in an execution context: the
+worker process on sequential runtimes, the coroutine's own storage under Swoole/OpenSwoole. Concurrent coroutines
+sharing one worker therefore no longer race on shared routing state.
 
-- **Safe**: sequential runtimes — FPM, FrankenPHP worker mode, RoadRunner, Swoole with a single in-flight
-  request per worker.
-- **Not safe**: Swoole coroutines sharing one connection concurrently (e.g. async requests in the same worker).
+- **Split mode (`read_only_replicas: true`)**: each request coroutine lazily builds its own master/replica client
+  pair — the same one-pair-per-request connection cost as FPM. Laravel's `pipeline()`/`transaction()` route to the
+  coroutine's master through the `client()` override, and the per-command client swap restores the previous
+  `$client` value, so interleaved commands cannot corrupt each other's routing.
+- **`persistent` is ignored inside coroutines** (forced to `0` for coroutine-created clients): phpredis' persistent
+  connection table is process-wide, so a persistent client created in a coroutine would share its socket with other
+  coroutines and reintroduce response interleaving. Persistent sockets keep working normally in FPM/CLI.
+- **Non-split mode**: every command uses the single client created at construction, shared by the whole worker.
+  Sharing one phpredis socket across concurrent coroutines carries the same caveat as plain Laravel + phpredis on
+  Octane — an upstream characteristic, not specific to Sentinel.
+- **Subscriptions still block their coroutine** (`subscribe`/`psubscribe` loop until the connection ends).
+- **Retry backoff still blocks the worker**: the retry delay sleeps the whole worker process, not just the
+  coroutine that hit the failure. Sequential runtimes are unaffected.
+- **Manager resolution is coroutine-safe**: `RedisSentinelManager` resolves `phpredis-sentinel` connections
+  without mutating its shared `$driver` property (non-Sentinel connections still temporarily swap it, matching
+  upstream's sequential assumption).
 
-If you rely on concurrent coroutines, disable `read_only_replicas` (everything routes to the master, no client
-swap) or keep R/W splitting on sequential workers.
+Safe/unsafe summary:
 
-The sequential contract is pinned by the hermetic `InterleavedRoutingTest` (unit) — coroutine-level races on the
-shared client swap are explicitly out of scope without ext-swoole in CI.
+- **Safe**: sequential runtimes — FPM, FrankenPHP worker mode, RoadRunner, and Swoole workers with a single
+  in-flight request per worker.
+- **Safe**: concurrent Swoole/OpenSwoole coroutines with `read_only_replicas` enabled — state and clients are
+  isolated per coroutine.
+- **Shared-socket caveat**: concurrent coroutines without R/W splitting share one client/socket — same caveat as
+  upstream Laravel on Octane.
+
+Per-context clients are created lazily per request. If connection churn ever becomes measurable in your workload,
+a connection pool is the documented upgrade path (deliberately not implemented).
+
+The sequential contract is pinned by the hermetic `InterleavedRoutingTest` (unit), and context isolation by
+`ContextIsolationTest`, which uses a switchable fake context to stand in for coroutine interleaving — real-Swoole
+interleaving tests are still out of scope without ext-swoole in CI (issue #65).
 
 ### No Configuration Needed
 

--- a/README.md
+++ b/README.md
@@ -526,7 +526,9 @@ The package is compatible with Laravel Octane and supports long-lived processes:
 
 Connection state (master/replica clients, stickiness, transaction level) lives in an execution context: the
 worker process on sequential runtimes, the coroutine's own storage under Swoole/OpenSwoole. Concurrent coroutines
-sharing one worker therefore no longer race on shared routing state.
+sharing one worker therefore no longer race on shared routing state. Runtime detection is extension-based
+(`class_exists` + coroutine id), not server-based: a Swoole/OpenSwoole extension loaded under any server — including
+RoadRunner or FrankenPHP workers — automatically switches connections to the coroutine-safe path.
 
 - **Split mode (`read_only_replicas: true`)**: each request coroutine lazily builds its own master/replica client
   pair — the same one-pair-per-request connection cost as FPM. Laravel's `pipeline()`/`transaction()` route to the

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ required.
 - ✅ Configurable retry logic for both Sentinel and Redis connections
 - ✅ Full support for Laravel Cache, Queue, Session, Broadcasting
 - ✅ Native Laravel Horizon integration
-- ✅ Laravel Octane compatible (sequential runtimes — see [Laravel Octane Support](#laravel-octane-support) for coroutine limits)
+- ✅ Laravel Octane compatible (concurrent coroutines safe in split mode — see [Laravel Octane Support](#laravel-octane-support) for the safe/unsafe matrix)
 
 ### Advanced Features
 
@@ -517,7 +517,7 @@ The package is compatible with Laravel Octane and supports long-lived processes:
 
 ```php
 // The package automatically handles:
-// ✅ Connection reuse across requests
+// ✅ Connection reuse across requests (FPM/CLI and non-split mode; split-mode coroutines create a fresh pair per request — see below)
 // ✅ Sticky session reset between requests
 // ✅ Graceful reconnection on failures
 ```

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # The merged matrix reports fluctuate by ~±0.2% between runs on
+        # timing-sensitive coverage; don't fail PRs on that noise.
+        threshold: 0.5%

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -187,12 +187,6 @@ parameters:
 			path: src/Connections/RedisSentinelConnection.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between null and Redis will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/Connections/RedisSentinelConnection.php
-
-		-
 			message: '#^Class RedisSentinel constructor invoked with 1 parameter, 2\-6 required\.$#'
 			identifier: arguments.count
 			count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,8 @@ parameters:
         - src
     bootstrapFiles:
         - vendor/autoload.php
+    ignoreErrors:
+        # OpenSwoole is an optional runtime: its classes are not installed in CI.
+        -
+            message: '#Call to static method (getCid|getContext)\(\) on an unknown class OpenSwoole\\Coroutine\.#'
+            path: src/Context/ExecutionContext.php

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -5,6 +5,9 @@ namespace Goopil\LaravelRedisSentinel\Connections;
 use Closure;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
 use Goopil\LaravelRedisSentinel\Concerns\Retryable;
+use Goopil\LaravelRedisSentinel\Context\ConnectionContext;
+use Goopil\LaravelRedisSentinel\Context\ConnectionState;
+use Goopil\LaravelRedisSentinel\Context\ExecutionContext;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionMaxRetryFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionReconnected;
@@ -84,15 +87,11 @@ class RedisSentinelConnection extends PhpRedisConnection
     protected ?array $readOnlyCommands = null;
 
     /**
-     * The master client instance (always writes to master).
-     * This reference is kept separate to guarantee writes always go to master.
+     * The master client instance provided at construction time. Non-split
+     * connections always use it; split connections use it as the worker/fallback
+     * state master so FPM never creates extra connections.
      */
-    protected \Redis $masterClient;
-
-    /**
-     * The read-only replica client instance.
-     */
-    protected ?\Redis $readClient = null;
+    protected \Redis $initialMaster;
 
     /**
      * The master connection creation callback.
@@ -109,14 +108,10 @@ class RedisSentinelConnection extends PhpRedisConnection
     protected $readConnector;
 
     /**
-     * Indicates if a write operation has been performed.
+     * Per-execution-unit storage (process slot for FPM/CLI, coroutine slot for
+     * Swoole/OpenSwoole). Lazily created so non-split connections never build one.
      */
-    protected bool $wroteToMaster = false;
-
-    /**
-     * The number of active transactions/pipelines.
-     */
-    protected int $transactionLevel = 0;
+    private ?ConnectionContext $context = null;
 
     /**
      * Create a new Redis Sentinel connection.
@@ -125,19 +120,61 @@ class RedisSentinelConnection extends PhpRedisConnection
      * @param  callable|null  $connector  Callback to create a new master connection
      * @param  array  $config  Connection configuration
      * @param  callable|null  $readConnector  Callback to create a new read-only connection
+     * @param  ConnectionContext|null  $context  Execution context store; defaults to a process/coroutine-aware one
      */
-    public function __construct($client, ?callable $connector = null, array $config = [], ?callable $readConnector = null)
+    public function __construct($client, ?callable $connector = null, array $config = [], ?callable $readConnector = null, ?ConnectionContext $context = null)
     {
         parent::__construct($client, $connector, $config);
 
-        $this->masterClient = $client;
+        $this->initialMaster = $client;
         $this->masterConnector = $connector;
         $this->readConnector = $readConnector;
+        $this->context = $context ?? ($readConnector === null ? null : new ExecutionContext);
+
+        // Seed the current (worker) slot with the constructor client: the FPM/CLI
+        // fallback keeps using it and creates no extra connection.
+        $this->state()->master = $client;
 
         $this->readOnlyCommands = array_unique(array_merge(
             self::READ_ONLY_COMMAND,
             array_map('strtolower', $config['read_commands'] ?? []),
         ));
+    }
+
+    /**
+     * The state of the current execution unit: stickiness, transaction level and
+     * its lazily created master/replica clients.
+     */
+    private function state(): ConnectionState
+    {
+        // Lazy fallback for partially mocked instances (no constructor ran).
+        $context = $this->context ??= new ExecutionContext;
+
+        return $context->storage()['state'] ??= new ConnectionState;
+    }
+
+    /**
+     * The current execution unit's master client: the constructor client in
+     * non-split mode, the context's lazily created one in split mode.
+     */
+    private function contextMaster(): \Redis
+    {
+        $state = $this->state();
+
+        return $state->master ??= $this->masterConnector
+            ? ($this->masterConnector)(false)
+            : $this->initialMaster;
+    }
+
+    /**
+     * Get the underlying Redis client: the current execution unit's master.
+     *
+     * Laravel's own pipeline()/transaction() call this method, which routes them
+     * to the right per-context master.
+     */
+    public function client(): \Redis
+    {
+        return $this->readConnector === null ? $this->initialMaster : $this->contextMaster();
     }
 
     /**
@@ -217,7 +254,7 @@ class RedisSentinelConnection extends PhpRedisConnection
             return $this->command('flushdb', $this->asyncFlushArguments((bool) $async));
         } finally {
             // Reset stickiness after flushing since all data is gone
-            $this->wroteToMaster = false;
+            $this->state()->wroteToMaster = false;
         }
     }
 
@@ -234,7 +271,7 @@ class RedisSentinelConnection extends PhpRedisConnection
             return $this->command('flushall', $sync === false ? $this->asyncFlushArguments(true) : []);
         } finally {
             // Reset stickiness after flushing since all data is gone
-            $this->wroteToMaster = false;
+            $this->state()->wroteToMaster = false;
         }
     }
 
@@ -262,7 +299,8 @@ class RedisSentinelConnection extends PhpRedisConnection
      */
     public function pipeline(?callable $callback = null): array|\Redis
     {
-        $this->transactionLevel++;
+        $state = $this->state();
+        $state->transactionLevel++;
 
         try {
             return $this->retry(
@@ -270,7 +308,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 __FUNCTION__
             );
         } finally {
-            $this->transactionLevel--;
+            $state->transactionLevel--;
         }
     }
 
@@ -279,7 +317,8 @@ class RedisSentinelConnection extends PhpRedisConnection
      */
     public function transaction(?callable $callback = null): array|\Redis
     {
-        $this->transactionLevel++;
+        $state = $this->state();
+        $state->transactionLevel++;
 
         try {
             return $this->retry(
@@ -287,7 +326,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 __FUNCTION__
             );
         } finally {
-            $this->transactionLevel--;
+            $state->transactionLevel--;
         }
     }
 
@@ -377,15 +416,17 @@ class RedisSentinelConnection extends PhpRedisConnection
                 $usedClient = $targetClient;
 
                 // CRITICAL: Temporarily swap $this->client to the target client
-                // This is necessary because parent class methods use $this->client
-                // We always restore to masterClient to ensure consistency
+                // This is necessary because parent class methods use $this->client.
+                // The swap is single-read-after-set (safe under cooperative scheduling):
+                // restoring the PREVIOUS value instead of the master keeps interleaved
+                // coroutines from restoring over each other's value.
+                $previous = $this->client;
                 $this->client = $targetClient;
 
                 try {
                     return $callback();
                 } finally {
-                    // Always restore to master client to ensure $this->client is never corrupted
-                    $this->client = $this->masterClient;
+                    $this->client = $previous;
                 }
             },
             onFail: function ($exception, $attempts) use ($name, $isReadOnly, &$usedClient, $onFailExtra) {
@@ -393,17 +434,20 @@ class RedisSentinelConnection extends PhpRedisConnection
 
                 $onFailExtra?->__invoke();
 
-                if ($usedClient !== $this->masterClient && $this->readConnector) {
+                $state = $this->state();
+
+                if ($usedClient !== $state->master && $this->readConnector) {
                     // The failing attempt ran on the read replica - refresh it
-                    $this->readClient = call_user_func($this->readConnector, true);
+                    $state->read = call_user_func($this->readConnector, true);
                 } else {
                     // The failing attempt ran on the master (write or sticky/fallback read)
                     // - refresh it
                     $newMasterClient = $this->masterConnector
                         ? call_user_func($this->masterConnector, true)
-                        : $this->masterClient;
+                        : $this->initialMaster;
 
-                    $this->masterClient = $newMasterClient;
+                    $state->master = $newMasterClient;
+                    $this->initialMaster = $newMasterClient;
                     $this->client = $newMasterClient;
                 }
 
@@ -438,7 +482,7 @@ class RedisSentinelConnection extends PhpRedisConnection
 
         // Mark stickiness for write operations
         if (! $isReadOnly) {
-            $this->wroteToMaster = true;
+            $this->state()->wroteToMaster = true;
         }
 
         return $result;
@@ -448,34 +492,37 @@ class RedisSentinelConnection extends PhpRedisConnection
      * Resolve the client instance for the given command.
      *
      * This method implements the read/write splitting logic:
-     * - Write commands ALWAYS return master client (guaranteed)
-     * - Read commands return replica IF:
-     *   - Read connector is configured
+     * - Non-split connections always use the constructor client
+     * - Write commands ALWAYS return the context's master client (guaranteed)
+     * - Read commands return the context's replica IF:
      *   - Not in a transaction/pipeline
      *   - No write has been performed (sticky session)
      *   - Command is actually read-only
-     * - Otherwise, return master client
+     * - Otherwise, return the context's master client
      *
      * @return \Redis The Redis client instance to use for this command
      */
     protected function resolveClientForCommand(string $method): \Redis
     {
-        // CRITICAL: Write commands ALWAYS use master
-        if (! $this->isReadOnlyCommand($method)) {
-            return $this->masterClient;
+        // Non-split mode: everything keeps using the constructor-provided client
+        if ($this->readConnector === null) {
+            return $this->initialMaster;
         }
 
-        // Read command: check if we can use replica
-        $canUseReplica = $this->readConnector !== null  // Replica configured
-            && $this->transactionLevel === 0            // Not in transaction
-            && ! $this->wroteToMaster;                  // No write performed (sticky session)
+        // CRITICAL: Write commands ALWAYS use master
+        if (! $this->isReadOnlyCommand($method)) {
+            return $this->contextMaster();
+        }
 
-        if ($canUseReplica) {
+        $state = $this->state();
+
+        // Read command: check if we can use the context's replica
+        if ($state->transactionLevel === 0 && ! $state->wroteToMaster) {
             return $this->getReadClient();
         }
 
-        // Fallback to master for read commands if replica not available or sticky
-        return $this->masterClient;
+        // Fallback to the context's master for read commands if sticky
+        return $this->contextMaster();
     }
 
     /**
@@ -483,24 +530,50 @@ class RedisSentinelConnection extends PhpRedisConnection
      */
     public function resetStickiness(): void
     {
-        $this->wroteToMaster = false;
-        $this->transactionLevel = 0;
+        $state = $this->state();
+        $state->wroteToMaster = false;
+        $state->transactionLevel = 0;
     }
 
     /**
-     * Get the read-only client instance.
+     * Get the read-only client instance of the current execution unit.
      */
     public function getReadClient(): \Redis
     {
-        if ($this->readClient) {
-            return $this->readClient;
+        $state = $this->state();
+
+        if ($state->read) {
+            return $state->read;
         }
 
         if ($this->readConnector) {
-            return $this->readClient = call_user_func($this->readConnector);
+            return $state->read = call_user_func($this->readConnector);
         }
 
-        return $this->masterClient;
+        return $this->initialMaster;
+    }
+
+    /**
+     * Disconnect the current execution unit's clients. In non-split mode this
+     * closes the constructor client, exactly like the parent implementation.
+     */
+    public function disconnect(): void
+    {
+        if ($this->readConnector === null) {
+            parent::disconnect();
+
+            return;
+        }
+
+        $state = $this->state();
+
+        try {
+            $state->master?->close();
+        } finally {
+            $state->read?->close();
+            $state->master = null;
+            $state->read = null;
+        }
     }
 
     /**

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -26,6 +26,10 @@ use Throwable;
  * overridden: the framework's __call routes dynamic commands through $this->command(),
  * so overriding it here would create nested retries (up to (limit+1)^2 attempts).
  *
+ * NOTE: PacksPhpRedisValues::pack() (used by RedisStore/PhpRedisLock) reads $this->client
+ * outside the swap — benign because all context clients share the same connection
+ * options/serializer.
+ *
  * @method mixed get(string $key) Get the value of a key
  * @method bool set(string $key, mixed $value, mixed $expireResolution = null, mixed $expireTTL = null, mixed $flag = null) Set the string value of a key
  * @method int|false del(string|array $key, ...$other_keys) Delete one or more keys
@@ -109,7 +113,9 @@ class RedisSentinelConnection extends PhpRedisConnection
 
     /**
      * Per-execution-unit storage (process slot for FPM/CLI, coroutine slot for
-     * Swoole/OpenSwoole). Lazily created so non-split connections never build one.
+     * Swoole/OpenSwoole). Lazily created on first state access. It is only an
+     * ArrayObject holder: non-split connections short-circuit per-context
+     * client creation elsewhere, so routing never builds clients from it.
      */
     private ?ConnectionContext $context = null;
 
@@ -129,7 +135,7 @@ class RedisSentinelConnection extends PhpRedisConnection
         $this->initialMaster = $client;
         $this->masterConnector = $connector;
         $this->readConnector = $readConnector;
-        $this->context = $context ?? ($readConnector === null ? null : new ExecutionContext);
+        $this->context = $context;
 
         // Seed the current (worker) slot with the constructor client: the FPM/CLI
         // fallback keeps using it and creates no extra connection.
@@ -417,9 +423,11 @@ class RedisSentinelConnection extends PhpRedisConnection
 
                 // CRITICAL: Temporarily swap $this->client to the target client
                 // This is necessary because parent class methods use $this->client.
-                // The swap is single-read-after-set (safe under cooperative scheduling):
-                // restoring the PREVIOUS value instead of the master keeps interleaved
-                // coroutines from restoring over each other's value.
+                // Routing never reads $this->client outside this swap window, which
+                // is what makes the swap safe under cooperative scheduling: with 3+
+                // interleaved coroutines the restores cascade and can leave $this->client
+                // pointing at a foreign context's master — harmless, since no command is
+                // ever dispatched through the stale value.
                 $previous = $this->client;
                 $this->client = $targetClient;
 

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -167,6 +167,9 @@ class RedisSentinelConnector extends PhpRedisConnector
      * sockets: the persistent connection table is process-wide, so such a
      * client would share its socket with other coroutines and reintroduce
      * response interleaving.
+     *
+     * @param  array<string, mixed>  $config
+     * @return array<string, mixed>
      */
     protected function buildClientConfig(array $config, string $ip, int $port): array
     {

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -6,6 +6,7 @@ use Closure;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
 use Goopil\LaravelRedisSentinel\Concerns\Retryable;
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\Context\ExecutionContext;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterMaxRetryFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelMasterReconnected;
@@ -44,6 +45,12 @@ class RedisSentinelConnector extends PhpRedisConnector
     private static ?float $breakerOpenedAt = null;
 
     private static ?Throwable $breakerLastException = null;
+
+    /**
+     * Test-only seam: forces the coroutine branch of buildClientConfig() without
+     * a running Swoole/OpenSwoole runtime. Must remain false in production.
+     */
+    public static bool $forceCoroutineDetection = false;
 
     public function __construct(NodeAddressCache $masterCache, ConfigRepository $config)
     {
@@ -150,7 +157,24 @@ class RedisSentinelConnector extends PhpRedisConnector
             ? $this->getReplicaAddress($config, $refresh)
             : $this->getMasterAddress($config, $refresh);
 
-        $clientConfig = array_merge(
+        return parent::createClient($this->buildClientConfig($config, $ip, $port));
+    }
+
+    /**
+     * Build the PhpRedis client options for a resolved node address.
+     *
+     * Clients created inside a coroutine must not use phpredis persistent
+     * sockets: the persistent connection table is process-wide, so such a
+     * client would share its socket with other coroutines and reintroduce
+     * response interleaving.
+     */
+    protected function buildClientConfig(array $config, string $ip, int $port): array
+    {
+        $persistent = self::$forceCoroutineDetection || ExecutionContext::inCoroutine()
+            ? 0
+            : Arr::get($config, 'persistent') ?? Arr::get($config, 'sentinel.persistent', 0);
+
+        return array_merge(
             Arr::get($config, 'options', []),
             [
                 'host' => $ip,
@@ -159,12 +183,10 @@ class RedisSentinelConnector extends PhpRedisConnector
                 'timeout' => Arr::get($config, 'timeout', 5.0),
                 'read_timeout' => Arr::get($config, 'read_timeout', 60.0),
                 'retry_interval' => Arr::get($config, 'retry_interval') ?? Arr::get($config, 'sentinel.retry_interval', 0),
-                'persistent' => Arr::get($config, 'persistent') ?? Arr::get($config, 'sentinel.persistent', 0),
+                'persistent' => $persistent,
                 'database' => Arr::get($config, 'database') ?? Arr::get($config, 'sentinel.database', 0),
             ]
         );
-
-        return parent::createClient($clientConfig);
     }
 
     /**

--- a/src/Context/ConnectionContext.php
+++ b/src/Context/ConnectionContext.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Context;
+
+interface ConnectionContext
+{
+    /**
+     * Storage slot bound to the current execution unit: the process for
+     * sequential runtimes, the coroutine for Swoole/OpenSwoole.
+     */
+    public function storage(): \ArrayObject;
+}

--- a/src/Context/ConnectionContext.php
+++ b/src/Context/ConnectionContext.php
@@ -7,6 +7,8 @@ interface ConnectionContext
     /**
      * Storage slot bound to the current execution unit: the process for
      * sequential runtimes, the coroutine for Swoole/OpenSwoole.
+     *
+     * @return \ArrayObject<string, mixed>
      */
     public function storage(): \ArrayObject;
 }

--- a/src/Context/ConnectionState.php
+++ b/src/Context/ConnectionState.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Context;
+
+final class ConnectionState
+{
+    public ?\Redis $master = null;
+
+    public ?\Redis $read = null;
+
+    public bool $wroteToMaster = false;
+
+    public int $transactionLevel = 0;
+}

--- a/src/Context/ExecutionContext.php
+++ b/src/Context/ExecutionContext.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Context;
+
+use Swoole\Coroutine;
+
+final class ExecutionContext implements ConnectionContext
+{
+    private static ?bool $coroutineRuntime = null;
+
+    private \ArrayObject $fallback;
+
+    public function __construct()
+    {
+        $this->fallback = new \ArrayObject;
+    }
+
+    public static function inCoroutine(): bool
+    {
+        if (self::$coroutineRuntime === null) {
+            self::$coroutineRuntime = class_exists(Coroutine::class)
+                || class_exists(\OpenSwoole\Coroutine::class);
+        }
+
+        if (! self::$coroutineRuntime) {
+            return false;
+        }
+
+        return class_exists(Coroutine::class)
+            ? Coroutine::getCid() > 0
+            : \OpenSwoole\Coroutine::getCid() > 0;
+    }
+
+    public function storage(): \ArrayObject
+    {
+        if (! self::inCoroutine()) {
+            return $this->fallback;
+        }
+
+        $context = class_exists(Coroutine::class)
+            ? Coroutine::getContext()
+            : \OpenSwoole\Coroutine::getContext();
+
+        if ($context instanceof \ArrayObject) {
+            // Keyed per connection: two connections may share one coroutine.
+            return $context['lrs-'.spl_object_id($this)] ??= new \ArrayObject;
+        }
+
+        return $this->fallback;
+    }
+}

--- a/src/Context/ExecutionContext.php
+++ b/src/Context/ExecutionContext.php
@@ -2,6 +2,7 @@
 
 namespace Goopil\LaravelRedisSentinel\Context;
 
+use Goopil\LaravelRedisSentinel\Exceptions\CoroutineContextException;
 use Swoole\Coroutine;
 
 final class ExecutionContext implements ConnectionContext
@@ -46,6 +47,11 @@ final class ExecutionContext implements ConnectionContext
             return $context['lrs-'.spl_object_id($this)] ??= new \ArrayObject;
         }
 
-        return $this->fallback;
+        // Silent fallback here would make every coroutine share the worker's
+        // state and reintroduce the cross-coroutine bug fixed in #66.
+        throw new CoroutineContextException(sprintf(
+            '%s returned an unexpected coroutine context (expected ArrayObject), refusing to fall back to shared worker state.',
+            class_exists(Coroutine::class) ? 'Swoole' : 'OpenSwoole'
+        ));
     }
 }

--- a/src/Context/ExecutionContext.php
+++ b/src/Context/ExecutionContext.php
@@ -27,9 +27,13 @@ final class ExecutionContext implements ConnectionContext
             return false;
         }
 
+        // Runtime detection requires a Swoole/OpenSwoole extension; both branches
+        // are unreachable in a plain-PHP test environment.
+        // @codeCoverageIgnoreStart
         return class_exists(Coroutine::class)
             ? Coroutine::getCid() > 0
             : \OpenSwoole\Coroutine::getCid() > 0;
+        // @codeCoverageIgnoreEnd
     }
 
     public function storage(): \ArrayObject
@@ -38,6 +42,7 @@ final class ExecutionContext implements ConnectionContext
             return $this->fallback;
         }
 
+        // @codeCoverageIgnoreStart
         $context = class_exists(Coroutine::class)
             ? Coroutine::getContext()
             : \OpenSwoole\Coroutine::getContext();
@@ -53,5 +58,6 @@ final class ExecutionContext implements ConnectionContext
             '%s returned an unexpected coroutine context (expected ArrayObject), refusing to fall back to shared worker state.',
             class_exists(Coroutine::class) ? 'Swoole' : 'OpenSwoole'
         ));
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/Context/ExecutionContext.php
+++ b/src/Context/ExecutionContext.php
@@ -9,6 +9,7 @@ final class ExecutionContext implements ConnectionContext
 {
     private static ?bool $coroutineRuntime = null;
 
+    /** @var \ArrayObject<string, mixed> */
     private \ArrayObject $fallback;
 
     public function __construct()
@@ -36,6 +37,9 @@ final class ExecutionContext implements ConnectionContext
         // @codeCoverageIgnoreEnd
     }
 
+    /**
+     * @return \ArrayObject<string, mixed>
+     */
     public function storage(): \ArrayObject
     {
         if (! self::inCoroutine()) {

--- a/src/Exceptions/CoroutineContextException.php
+++ b/src/Exceptions/CoroutineContextException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Exception to be used if the coroutine runtime does not return the expected per-coroutine storage.
+ */
+class CoroutineContextException extends RuntimeException {}

--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -24,32 +24,34 @@ class RedisSentinelManager extends RedisManager
         $name = $name ?: 'default';
 
         $normalizedName = $this->patchHorizonConnectionName($name);
-        $previousDriver = $this->driver;
-        $this->driver = $this->config[$normalizedName]['client'] ?? $this->driver;
+        $clientDriver = $this->config[$normalizedName]['client'] ?? $this->driver;
 
-        try {
-            if ($this->driver !== 'phpredis-sentinel') {
+        if ($clientDriver !== 'phpredis-sentinel') {
+            $previousDriver = $this->driver;
+            $this->driver = $clientDriver;
+
+            try {
                 return parent::resolve($normalizedName);
+            } finally {
+                $this->driver = $previousDriver;
             }
-
-            $config = $this->parseConnectionConfiguration($this->config[$normalizedName]);
-
-            $config = $this->patchHorizonPrefix(
-                $name,
-                $config
-            );
-
-            $options = $this->config['options'] ?? [];
-
-            $options = array_merge(
-                Arr::except($options, 'parameters'),
-                ['parameters' => Arr::get($options, 'parameters.'.$name, Arr::get($options, 'parameters', []))]
-            );
-
-            return $this->connector()->connect($config, $options);
-        } finally {
-            $this->driver = $previousDriver;
         }
+
+        $config = $this->parseConnectionConfiguration($this->config[$normalizedName]);
+
+        $config = $this->patchHorizonPrefix(
+            $name,
+            $config
+        );
+
+        $options = $this->config['options'] ?? [];
+
+        $options = array_merge(
+            Arr::except($options, 'parameters'),
+            ['parameters' => Arr::get($options, 'parameters.'.$name, Arr::get($options, 'parameters', []))]
+        );
+
+        return $this->sentinelConnector()->connect($config, $options);
     }
 
     public function resolveConnector($name = null): Connector|PhpRedisConnector|PredisConnector|RedisSentinelConnector
@@ -68,6 +70,10 @@ class RedisSentinelManager extends RedisManager
             );
         }
 
+        if (($this->config[$normalizedName]['client'] ?? $this->driver) === 'phpredis-sentinel') {
+            return $this->sentinelConnector();
+        }
+
         $previousDriver = $this->driver;
         $this->driver = $this->config[$normalizedName]['client'] ?? $this->driver;
 
@@ -76,6 +82,22 @@ class RedisSentinelManager extends RedisManager
         } finally {
             $this->driver = $previousDriver;
         }
+    }
+
+    /**
+     * Resolve the connector registered for the sentinel driver without
+     * consulting or mutating the shared $driver property, so concurrent
+     * resolutions (e.g. Swoole coroutines) never observe a swapped driver.
+     */
+    private function sentinelConnector(): Connector
+    {
+        $creator = $this->customCreators['phpredis-sentinel'] ?? null;
+
+        if ($creator === null) {
+            throw new ConfigurationException('No connector registered for the [phpredis-sentinel] driver.');
+        }
+
+        return $creator();
     }
 
     protected function isHorizonContext(): bool

--- a/tests/Feature/ConnectionRetryTest.php
+++ b/tests/Feature/ConnectionRetryTest.php
@@ -89,11 +89,10 @@ describe('Reconnect', function () {
         $connection->setRetryDelay(1);
         $connection->setRetryMessages(['broken pipe']);
 
-        $property = (new ReflectionClass($connection))->getProperty('wroteToMaster');
-        $property->setValue($connection, true);
+        connectionState($connection)->wroteToMaster = true;
 
         expect(fn () => $connection->flushdb())->toThrow(RedisException::class)
-            ->and($property->getValue($connection))->toBeFalse();
+            ->and(connectionState($connection)->wroteToMaster)->toBeFalse();
     });
 
     test('flushall routes once through the client and resets stickiness', function () {
@@ -104,11 +103,10 @@ describe('Reconnect', function () {
 
         $connection = new RedisSentinelConnection($client, fn () => $client, []);
 
-        $property = (new ReflectionClass($connection))->getProperty('wroteToMaster');
-        $property->setValue($connection, true);
+        connectionState($connection)->wroteToMaster = true;
 
         expect($connection->flushall())->toBeTrue()
-            ->and($property->getValue($connection))->toBeFalse();
+            ->and(connectionState($connection)->wroteToMaster)->toBeFalse();
     });
 
     test('Reconnecting after a manual fail over', function () {

--- a/tests/Feature/Horizon/HorizonE2ENoSplitTest.php
+++ b/tests/Feature/Horizon/HorizonE2ENoSplitTest.php
@@ -58,9 +58,7 @@ describe('Horizon E2E Tests WITHOUT Read/Write Splitting - Master Only', functio
         $connection->get('horizon:master:read');
         $connection->set('horizon:master:write', 'value');
 
-        // No stickiness tracking needed in master-only mode
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('All operations go to master');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('All operations go to master');
     });
 
     test('horizon processes jobs correctly in master-only mode', function () {

--- a/tests/Feature/Horizon/HorizonE2ETest.php
+++ b/tests/Feature/Horizon/HorizonE2ETest.php
@@ -49,7 +49,7 @@ describe('Horizon E2E Tests with Read/Write Mode and Failover', function () {
         }
 
         $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
+        $wroteToMasterState = connectionState($connection);
 
         // Test read operation (should not trigger stickiness if read/write splitting is enabled)
         $connection->get('horizon:test:read');
@@ -62,7 +62,7 @@ describe('Horizon E2E Tests with Read/Write Mode and Failover', function () {
         // Test write operation (should use master and activate stickiness)
         $connection->set('horizon:test:write', 'value');
 
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Stickiness should be activated after write');
+        expect($wroteToMasterState->wroteToMaster)->toBeTrue('Stickiness should be activated after write');
 
         // If read/write splitting is available, verify it was initialized
         if ($hasReadConnector) {
@@ -325,11 +325,8 @@ describe('Horizon E2E Tests with Read/Write Mode and Failover', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Start with no stickiness
-        expect($wroteToMasterProp->getValue($connection))->toBeFalse();
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse();
 
         // Perform multiple read operations
         for ($i = 1; $i <= 5; $i++) {
@@ -337,13 +334,13 @@ describe('Horizon E2E Tests with Read/Write Mode and Failover', function () {
         }
 
         // Should still not have stickiness
-        expect($wroteToMasterProp->getValue($connection))->toBeFalse('Reads should not trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse('Reads should not trigger stickiness');
 
         // Perform a write operation
         $connection->set('horizon:write:key', 'value');
 
         // Now stickiness should be active
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Write should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Write should trigger stickiness');
 
         // Subsequent reads should use master due to stickiness
         for ($i = 1; $i <= 5; $i++) {
@@ -351,6 +348,6 @@ describe('Horizon E2E Tests with Read/Write Mode and Failover', function () {
         }
 
         // Stickiness should remain
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Stickiness should persist');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Stickiness should persist');
     });
 });

--- a/tests/Feature/Horizon/HorizonFailoverTest.php
+++ b/tests/Feature/Horizon/HorizonFailoverTest.php
@@ -331,12 +331,9 @@ describe('Horizon Failover Tests - Redis Sentinel Master Failover', function () 
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Perform writes
         $connection->set('failover:rw:test1', 'value1');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Write should activate stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Write should activate stickiness');
 
         // Simulate failover
         try {
@@ -354,7 +351,7 @@ describe('Horizon Failover Tests - Redis Sentinel Master Failover', function () 
 
         // Perform another write after failover
         $connection->set('failover:rw:test2', 'value2');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Write should reactivate stickiness after failover');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Write should reactivate stickiness after failover');
 
         // Verify data integrity
         expect($connection->get('failover:rw:test1'))->toBe('value1')

--- a/tests/Feature/OctaneCompatibilityTest.php
+++ b/tests/Feature/OctaneCompatibilityTest.php
@@ -14,34 +14,43 @@ test('wrote to master is reset with reset stickiness', function () {
 
     $connection = new RedisSentinelConnection($masterClient, $connector, [], $readConnector);
 
+    $masterClient->shouldReceive('set')->once()->with('foo', 'bar', null)->andReturn(true);
+    $masterClient->shouldReceive('get')->once()->with('foo')->andReturn('from-master');
+    $replicaClient->shouldReceive('get')->once()->with('foo')->andReturn('from-replica');
+
     // Simulate a write
-    $masterClient->expects('set')->once()->andReturn(true);
     $connection->set('foo', 'bar');
 
-    $reflection = new ReflectionClass($connection);
-    $property = $reflection->getProperty('wroteToMaster');
-
-    expect($property->getValue($connection))->toBeTrue();
+    // Reads stick to the master after a write
+    expect($connection->get('foo'))->toBe('from-master');
 
     // Call reset
     $connection->resetStickiness();
 
-    expect($property->getValue($connection))->toBeFalse();
+    // Reads go back to the replica
+    expect($connection->get('foo'))->toBe('from-replica');
 });
 
 test('resetStickiness also resets transaction level', function () {
     $masterClient = Mockery::mock(Redis::class);
+    $replicaClient = Mockery::mock(Redis::class);
 
-    $connection = new RedisSentinelConnection($masterClient, fn () => $masterClient, []);
+    $masterClient->shouldReceive('multi')->once()->andReturnSelf();
+    $masterClient->shouldReceive('exec')->once()->andReturn([]);
+    $masterClient->shouldReceive('get')->once()->with('in-tx')->andReturn('from-master');
+    $replicaClient->shouldReceive('get')->once()->with('in-tx')->andReturn('from-replica');
 
-    $reflection = new ReflectionClass($connection);
-    $transactionProp = $reflection->getProperty('transactionLevel');
-    $transactionProp->setAccessible(true);
-    $transactionProp->setValue($connection, 3);
+    $connection = new RedisSentinelConnection($masterClient, fn () => $masterClient, [], fn () => $replicaClient);
 
-    $connection->resetStickiness();
+    $connection->transaction(function () use ($connection): void {
+        // Inside an open transaction reads stay on the master
+        expect($connection->get('in-tx'))->toBe('from-master');
 
-    expect($transactionProp->getValue($connection))->toBe(0);
+        $connection->resetStickiness();
+
+        // The reset dropped the transaction level: reads reach the replica
+        expect($connection->get('in-tx'))->toBe('from-replica');
+    });
 });
 
 test('bootOctane listens to all Octane lifecycle events', function () {
@@ -78,8 +87,14 @@ test('octane lifecycle callback resets stickiness on all sentinel connections', 
     $replicaClient = Mockery::mock(Redis::class);
     $connection = new RedisSentinelConnection($masterClient, fn () => $masterClient, [], fn () => $replicaClient);
 
-    $masterClient->expects('set')->once()->andReturn(true);
+    $masterClient->shouldReceive('set')->once()->with('foo', 'bar', null)->andReturn(true);
+    $masterClient->shouldReceive('get')->once()->with('foo')->andReturn('from-master');
+    $replicaClient->shouldReceive('get')->once()->with('foo')->andReturn('from-replica');
+
     $connection->set('foo', 'bar');
+
+    // Reads stick to the master after the write
+    expect($connection->get('foo'))->toBe('from-master');
 
     $manager = app(RedisSentinelManager::class);
     $connectionsProp = new ReflectionProperty(RedisSentinelManager::class, 'connections');
@@ -101,7 +116,6 @@ test('octane lifecycle callback resets stickiness on all sentinel connections', 
 
     ($captured['Laravel\Octane\Events\TaskReceived'])();
 
-    $wroteProp = (new ReflectionClass($connection))->getProperty('wroteToMaster');
-
-    expect($wroteProp->getValue($connection))->toBeFalse();
+    // Reads go back to the replica: the lifecycle callback reset stickiness
+    expect($connection->get('foo'))->toBe('from-replica');
 });

--- a/tests/Feature/Orchestra/BroadcastE2EFailoverTest.php
+++ b/tests/Feature/Orchestra/BroadcastE2EFailoverTest.php
@@ -243,12 +243,9 @@ describe('Broadcast E2E Failover Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Publish (write operation)
         $connection->publish('test-channel', 'message1');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue();
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue();
 
         // Simulate failover
         try {

--- a/tests/Feature/Orchestra/BroadcastE2ENoSplitTest.php
+++ b/tests/Feature/Orchestra/BroadcastE2ENoSplitTest.php
@@ -267,12 +267,9 @@ describe('Broadcast E2E Tests WITHOUT Read/Write Splitting - Master Only', funct
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // In master-only mode, all operations go to master
         $connection->publish('test-channel', 'test-message');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue();
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue();
     });
 
     test('broadcast handles concurrent events in master-only mode', function () {

--- a/tests/Feature/Orchestra/BroadcastE2ETest.php
+++ b/tests/Feature/Orchestra/BroadcastE2ETest.php
@@ -54,9 +54,6 @@ describe('Broadcast E2E Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Broadcasting is a write operation (publishes to Redis channels)
         Queue::fake();
         $event = new UserRegistered(1, 'test', 'test@example.com');
@@ -278,16 +275,13 @@ describe('Broadcast E2E Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Check channel subscription list (operational command)
         $connection->pubsub('channels', 'user-*');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('PUBSUB should stay on master and trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('PUBSUB should stay on master and trigger stickiness');
 
         // Publish to channel (write operation)
         $connection->publish('user-registrations', json_encode(['user_id' => 1]));
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Publish should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Publish should trigger stickiness');
     });
 
     test('broadcast handles concurrent events efficiently', function () {

--- a/tests/Feature/Orchestra/CacheE2EFailoverTest.php
+++ b/tests/Feature/Orchestra/CacheE2EFailoverTest.php
@@ -40,16 +40,13 @@ describe('Cache E2E Failover Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Cache read should not trigger stickiness
         Cache::get('test_key');
-        expect($wroteToMasterProp->getValue($connection))->toBeFalse('Cache read should not trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse('Cache read should not trigger stickiness');
 
         // Cache write should trigger stickiness
         Cache::put('test_key', 'test_value', 60);
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Cache write should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Cache write should trigger stickiness');
     });
 
     test('cache stores and retrieves data with read/write mode', function () {

--- a/tests/Feature/Orchestra/CacheE2ENoSplitTest.php
+++ b/tests/Feature/Orchestra/CacheE2ENoSplitTest.php
@@ -50,8 +50,7 @@ describe('Cache E2E Tests WITHOUT Read/Write Splitting - Master Only', function 
         Cache::get('test_key');
         Cache::put('test_key', 'test_value', 60);
 
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('All operations use master');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('All operations use master');
     });
 
     test('cache stores and retrieves in master-only mode', function () {

--- a/tests/Feature/Orchestra/OctaneIntegrationTest.php
+++ b/tests/Feature/Orchestra/OctaneIntegrationTest.php
@@ -19,11 +19,7 @@ describe('Octane Integration', function () {
         // 1. Perform a write to make it sticky
         $connection->set('sticky_test', 'value');
 
-        // Use reflection to check wroteToMaster
-        $reflection = new ReflectionClass($connection);
-        $property = $reflection->getProperty('wroteToMaster');
-
-        expect($property->getValue($connection))->toBeTrue();
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue();
 
         // 2. Fire the Octane event
         // Note: The event class might not exist if Octane is not installed,
@@ -50,6 +46,6 @@ describe('Octane Integration', function () {
         }
 
         // 3. Verify it's no longer sticky
-        expect($property->getValue($connection))->toBeFalse();
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse();
     });
 });

--- a/tests/Feature/Orchestra/QueueE2EFailoverTest.php
+++ b/tests/Feature/Orchestra/QueueE2EFailoverTest.php
@@ -52,23 +52,20 @@ describe('Queue E2E Failover Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Queue push is a write operation
         $connection->rpush('queues:test', 'job_payload');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Queue push should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Queue push should trigger stickiness');
 
         // Reset for next test
         $connection->resetStickiness();
 
         // Queue read operations
         $connection->llen('queues:test');
-        expect($wroteToMasterProp->getValue($connection))->toBeFalse('Queue length check should not trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse('Queue length check should not trigger stickiness');
 
         // Queue pop is a write operation
         $connection->lpop('queues:test');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Queue pop should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Queue pop should trigger stickiness');
     });
 
     test('queue jobs are processed correctly with read/write mode', function () {

--- a/tests/Feature/Orchestra/QueueE2ENoSplitTest.php
+++ b/tests/Feature/Orchestra/QueueE2ENoSplitTest.php
@@ -62,8 +62,7 @@ describe('Queue E2E Tests WITHOUT Read/Write Splitting - Master Only', function 
         $connection->rpush($queueKey, 'job1');
         $connection->lpop($queueKey);
 
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('All operations use master');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('All operations use master');
     });
 
     test('queue processes jobs correctly in master-only mode', function () {

--- a/tests/Feature/Orchestra/QueueStickinessTest.php
+++ b/tests/Feature/Orchestra/QueueStickinessTest.php
@@ -17,10 +17,7 @@ describe('Queue Stickiness', function () {
         // 1. Perform a write to make it sticky
         $connection->set('sticky_queue_test', 'value');
 
-        $reflection = new ReflectionClass($connection);
-        $property = $reflection->getProperty('wroteToMaster');
-
-        expect($property->getValue($connection))->toBeTrue();
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue();
 
         // 2. Fire the JobProcessing event
         // The JobProcessing event constructor requires connection name and job instance.
@@ -30,6 +27,6 @@ describe('Queue Stickiness', function () {
         Event::dispatch(new JobProcessing('phpredis-sentinel', $job));
 
         // 3. Verify it's no longer sticky
-        expect($property->getValue($connection))->toBeFalse();
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse();
     });
 });

--- a/tests/Feature/Orchestra/ReadWriteSplittingTest.php
+++ b/tests/Feature/Orchestra/ReadWriteSplittingTest.php
@@ -39,18 +39,14 @@ describe('Read/Write', function () {
 
     function getInternalState($connection)
     {
-        $reflection = new ReflectionClass($connection);
+        $state = connectionState($connection);
 
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
-        $readClientProp = $reflection->getProperty('readClient');
-
-        $readConnectorProp = $reflection->getProperty('readConnector');
+        $readConnector = (new ReflectionClass($connection))->getProperty('readConnector')->getValue($connection);
 
         return [
-            'wroteToMaster' => $wroteToMasterProp->getValue($connection),
-            'hasReadClient' => ! is_null($readClientProp->getValue($connection)),
-            'hasReadConnector' => ! is_null($readConnectorProp->getValue($connection)),
+            'wroteToMaster' => $state->wroteToMaster,
+            'hasReadClient' => $state->read !== null,
+            'hasReadConnector' => $readConnector !== null,
         ];
     }
 

--- a/tests/Feature/Orchestra/SessionE2EFailoverTest.php
+++ b/tests/Feature/Orchestra/SessionE2EFailoverTest.php
@@ -46,18 +46,15 @@ describe('Session E2E Failover Tests with Read/Write Mode', function () {
             $this->markTestSkipped('Not using RedisSentinelConnection');
         }
 
-        $reflection = new ReflectionClass($connection);
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-
         // Session read should not trigger stickiness initially
         Session::get('test_key');
-        expect($wroteToMasterProp->getValue($connection))->toBeFalse('Session read should not trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeFalse('Session read should not trigger stickiness');
 
         // Session write should trigger stickiness
         Session::put('test_key', 'test_value');
         Session::save(); // Force write to Redis
 
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('Session write should trigger stickiness');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('Session write should trigger stickiness');
     });
 
     test('session stores and retrieves data with read/write mode', function () {

--- a/tests/Feature/Orchestra/SessionE2ENoSplitTest.php
+++ b/tests/Feature/Orchestra/SessionE2ENoSplitTest.php
@@ -55,8 +55,7 @@ describe('Session E2E Tests WITHOUT Read/Write Splitting - Master Only', functio
         Session::put('test_key', 'test_value');
         Session::save();
 
-        $wroteToMasterProp = $reflection->getProperty('wroteToMaster');
-        expect($wroteToMasterProp->getValue($connection))->toBeTrue('All operations use master');
+        expect(connectionState($connection)->wroteToMaster)->toBeTrue('All operations use master');
     });
 
     test('session stores and retrieves in master-only mode', function () {

--- a/tests/Feature/QueueStickinessTest.php
+++ b/tests/Feature/QueueStickinessTest.php
@@ -6,14 +6,12 @@ use Illuminate\Queue\Events\JobProcessing;
 test('stickiness is reset on job processing', function () {
     $connection = getRedisSentinelConnection();
 
-    $reflection = new ReflectionClass($connection);
-    $property = $reflection->getProperty('wroteToMaster');
-    $property->setValue($connection, true);
+    connectionState($connection)->wroteToMaster = true;
 
     $job = Mockery::mock(Job::class);
     $job->allows('payload')->andReturn([]);
 
     event(new JobProcessing('redis', $job));
 
-    expect($property->getValue($connection))->toBeFalse();
+    expect(connectionState($connection)->wroteToMaster)->toBeFalse();
 });

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -288,9 +288,7 @@ test('it is always sticky when read only replicas is active', function () {
 
     $connection->set('foo', 'bar');
 
-    $reflection = new ReflectionClass($connection);
-    $property = $reflection->getProperty('wroteToMaster');
-    expect($property->getValue($connection))->toBeTrue();
+    expect(connectionState($connection)->wroteToMaster)->toBeTrue();
 
     expect($connection->get('foo'))->toBe('bar');
 });
@@ -725,27 +723,23 @@ test('master client reference is never corrupted', function () {
 
     $connection = new RedisSentinelConnection($masterClient, $connector, [], $readConnector);
 
-    // Use reflection to verify internal state
-    $reflection = new ReflectionClass($connection);
-    $masterClientProp = $reflection->getProperty('masterClient');
-
     // First read goes to replica
     expect($connection->get('key'))->toBe('value');
 
     // Verify master client reference is unchanged
-    expect($masterClientProp->getValue($connection))->toBe($masterClient);
+    expect($connection->client())->toBe($masterClient);
 
     // Write goes to master
     expect($connection->set('key', 'newvalue'))->toBeTrue();
 
     // Verify master client reference is STILL unchanged
-    expect($masterClientProp->getValue($connection))->toBe($masterClient);
+    expect($connection->client())->toBe($masterClient);
 
     // Subsequent read goes to master due to stickiness
     expect($connection->get('key2'))->toBe('value2');
 
     // Verify master client reference is STILL unchanged
-    expect($masterClientProp->getValue($connection))->toBe($masterClient);
+    expect($connection->client())->toBe($masterClient);
 });
 
 test('it allows custom read-only commands from config', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,6 +13,8 @@
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Context\ConnectionState;
+use Goopil\LaravelRedisSentinel\Context\ExecutionContext;
 use Goopil\LaravelRedisSentinel\Tests\Support\Toxiproxy\InteractsWithToxiproxy;
 use Goopil\LaravelRedisSentinel\Tests\TestCase;
 use Illuminate\Redis\Connections\PhpRedisConnection;
@@ -74,6 +76,28 @@ expect()->extend('toBeAWorkingRedisConnection', function () {
 function getRedisSentinelConnection()
 {
     return app()->get('redis')->connection('phpredis-sentinel');
+}
+
+/**
+ * The live ConnectionState of the connection's current execution slot.
+ * State moved into per-context storage, so tests assert stickiness
+ * (and seed it) through this accessor instead of instance properties.
+ */
+function connectionState(RedisSentinelConnection $connection): ConnectionState
+{
+    // Mirrors the connection's lazy context init: non-split connections only
+    // build their context on first use, and partially mocked instances never run
+    // the constructor at all. The property is resolved from its declaring class
+    // because Mockery proxies hide inherited private properties.
+    $property = new ReflectionProperty(RedisSentinelConnection::class, 'context');
+    $context = $property->getValue($connection);
+
+    if ($context === null) {
+        $context = new ExecutionContext;
+        $property->setValue($connection, $context);
+    }
+
+    return $context->storage()['state'] ??= new ConnectionState;
 }
 
 /**

--- a/tests/Support/FakeContext.php
+++ b/tests/Support/FakeContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Tests\Support;
+
+use Goopil\LaravelRedisSentinel\Context\ConnectionContext;
+
+final class FakeContext implements ConnectionContext
+{
+    private string $slot = 'default';
+
+    /** @var array<string, \ArrayObject> */
+    private array $slots = [];
+
+    public function use(string $slot): void
+    {
+        $this->slot = $slot;
+    }
+
+    public function currentSlot(): string
+    {
+        return $this->slot;
+    }
+
+    public function storage(): \ArrayObject
+    {
+        return $this->slots[$this->slot] ??= new \ArrayObject;
+    }
+}

--- a/tests/Unit/Connections/ContextIsolationTest.php
+++ b/tests/Unit/Connections/ContextIsolationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\Tests\Support\FakeContext;
+
+// ponytail: sequential slot switches stand in for Swoole coroutine interleaving
+
+test('stickiness does not leak between execution contexts', function () {
+    $masterA = Mockery::mock(Redis::class);
+    $masterB = Mockery::mock(Redis::class);
+    $replica = Mockery::mock(Redis::class);
+
+    $masters = ['a' => $masterA, 'b' => $masterB];
+    $context = new FakeContext;
+
+    $connection = new RedisSentinelConnection(
+        $masterA,
+        fn () => $masters[$context->currentSlot()], // resolves per current slot
+        [],
+        fn () => $replica,
+        $context,
+    );
+
+    $context->use('a');
+    $masterA->shouldReceive('set')->once()->with('k', 'v', null)->andReturn(true);
+    $connection->set('k', 'v');
+
+    $context->use('b');
+    // B reads first: A's stickiness must not leak into B's state
+    $replica->shouldReceive('get')->once()->with('k')->andReturn('from-replica');
+    $masterB->shouldReceive('get')->never();
+    expect($connection->get('k'))->toBe('from-replica');
+
+    // B writes on ITS own master, not masterA
+    $masterB->shouldReceive('set')->once()->with('k', 'v', null)->andReturn(true);
+    $masterA->shouldReceive('set')->never();
+    expect($connection->set('k', 'v'))->toBeTrue();
+
+    // And now B is sticky on ITS master
+    $masterB->shouldReceive('get')->once()->with('k')->andReturn('from-master-b');
+    expect($connection->get('k'))->toBe('from-master-b');
+});
+
+test('each execution context gets its own master client in split mode', function () {
+    $context = new FakeContext;
+    $created = [];
+
+    $connection = new RedisSentinelConnection(
+        Mockery::mock(Redis::class), // the worker client: contexts never reuse it
+        function () use (&$created, $context) {
+            return $created[$context->currentSlot()] ??= Mockery::mock(Redis::class);
+        },
+        [],
+        fn () => Mockery::mock(Redis::class),
+        $context,
+    );
+
+    $context->use('a');
+    $masterA = $connection->client();
+
+    $context->use('b');
+    $masterB = $connection->client();
+
+    expect($masterA)->not->toBe($masterB)
+        ->and(spl_object_id($masterA))->not->toBe(spl_object_id($masterB))
+        // Stable within the same slot
+        ->and($connection->client())->toBe($masterB);
+});
+
+test('transaction level is scoped to the current execution context', function () {
+    $master = Mockery::mock(Redis::class);
+    $replica = Mockery::mock(Redis::class);
+    $context = new FakeContext;
+
+    $master->shouldReceive('multi')->once()->andReturnSelf();
+    $master->shouldReceive('exec')->once()->andReturn([]);
+
+    $connection = new RedisSentinelConnection($master, fn () => $master, [], fn () => $replica, $context);
+
+    $context->use('tx');
+    $connection->transaction(function () use ($connection, $context, $master, $replica): void {
+        // While the transaction is open in slot 'tx', another context is unaffected
+        $context->use('other');
+        $replica->shouldReceive('get')->once()->with('peek')->andReturn('from-replica');
+        $master->shouldReceive('get')->never();
+        expect($connection->get('peek'))->toBe('from-replica');
+
+        $context->use('tx');
+    });
+});

--- a/tests/Unit/Connections/InterleavedRoutingTest.php
+++ b/tests/Unit/Connections/InterleavedRoutingTest.php
@@ -27,9 +27,8 @@ test('interleaved reads and writes on one shared connection route to the right c
 
     $connection->set('k1', 'v1');
 
-    expect((new ReflectionProperty($connection, 'wroteToMaster'))->getValue($connection))->toBeTrue()
-        ->and((new ReflectionProperty($connection, 'client'))->getValue($connection))->toBe($master)
-        ->and((new ReflectionProperty($connection, 'readClient'))->getValue($connection))->toBe($replica);
+    expect($connection->client())->toBe($master)
+        ->and($connection->getReadClient())->toBe($replica);
 });
 
 test('resetting stickiness flips reads back to the replica after a write', function () {
@@ -58,7 +57,9 @@ test('reads issued inside a transaction are routed to the master', function () {
     $master->shouldReceive('multi')->once()->andReturnSelf();
     $master->shouldReceive('exec')->once()->andReturn([]);
     $master->shouldReceive('get')->once()->with('in-tx')->andReturn('from-master');
-    $replica->shouldReceive('get')->never();
+    $master->shouldReceive('get')->with('after-tx')->never();
+    $replica->shouldReceive('get')->never()->with('in-tx');
+    $replica->shouldReceive('get')->once()->with('after-tx')->andReturn('from-replica');
 
     $connection = new RedisSentinelConnection($master, fn () => $master, [], fn () => $replica);
 
@@ -66,5 +67,9 @@ test('reads issued inside a transaction are routed to the master', function () {
         expect($connection->get('in-tx'))->toBe('from-master');
     });
 
-    expect((new ReflectionProperty($connection, 'transactionLevel'))->getValue($connection))->toBe(0);
+    // Clear the stickiness the transaction itself set; the read then reaching the
+    // replica proves the transaction level is back to zero
+    $connection->resetStickiness();
+
+    expect($connection->get('after-tx'))->toBe('from-replica');
 });

--- a/tests/Unit/Connections/InterleavedRoutingTest.php
+++ b/tests/Unit/Connections/InterleavedRoutingTest.php
@@ -67,6 +67,9 @@ test('reads issued inside a transaction are routed to the master', function () {
         expect($connection->get('in-tx'))->toBe('from-master');
     });
 
+    // The finally block must release the level, or reads are pinned to master forever
+    expect(connectionState($connection)->transactionLevel)->toBe(0);
+
     // Clear the stickiness the transaction itself set; the read then reaching the
     // replica proves the transaction level is back to zero
     $connection->resetStickiness();

--- a/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionFlushTest.php
@@ -28,11 +28,10 @@ test('flush methods reset master stickiness even when the command fails', functi
     $connection = Mockery::mock(RedisSentinelConnection::class)->makePartial();
     $connection->shouldReceive('command')->once()->with('flushall', [])->andThrow(new RuntimeException('boom'));
 
-    $stickiness = new ReflectionProperty(RedisSentinelConnection::class, 'wroteToMaster');
-    $stickiness->setValue($connection, true);
+    connectionState($connection)->wroteToMaster = true;
 
     expect(fn () => $connection->flushall())->toThrow(RuntimeException::class)
-        ->and($stickiness->getValue($connection))->toBeFalse();
+        ->and(connectionState($connection)->wroteToMaster)->toBeFalse();
 });
 
 /**

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -2,6 +2,7 @@
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionFailed;
+use Goopil\LaravelRedisSentinel\Tests\Support\FakeContext;
 use Illuminate\Support\Facades\Event;
 
 test('a failing dynamic command is retried exactly retryLimit + 1 times', function () {
@@ -100,6 +101,28 @@ test('parent command() cannot reconnect or nest retries on Laravel 13', function
         expect($exception->getMessage())->toBe('went away')
             ->and($reconnects)->toBe(3);
     }
+});
+
+test('a split connection without a master connector falls back to the constructor client', function () {
+    Event::fake();
+
+    $master = Mockery::mock(Redis::class);
+    $replica = Mockery::mock(Redis::class);
+    $context = new FakeContext;
+
+    $master->expects('set')->with('foo', 'bar', null)->twice()->andReturnUsing(
+        fn () => throw new RedisException('broken pipe'),
+        fn () => true,
+    );
+    $replica->shouldNotReceive('set');
+
+    $connection = new RedisSentinelConnection($master, null, [], fn () => $replica, $context);
+    $connection->setRetryLimit(1);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(['broken pipe']);
+
+    $context->use('fresh');
+    expect($connection->set('foo', 'bar'))->toBeTrue();
 });
 
 test('a retried scan restarts its cursor on the refreshed client', function () {

--- a/tests/Unit/Connectors/ClientConfigTest.php
+++ b/tests/Unit/Connectors/ClientConfigTest.php
@@ -35,3 +35,13 @@ test('persistent is forced to zero for coroutine-created clients', function () {
 
     expect($result['persistent'])->toBe(0);
 });
+
+test('sentinel.persistent fallback is preserved for workers and forced to zero in coroutines', function () {
+    $config = ['sentinel' => ['persistent' => 30]];
+
+    expect(clientConfigConnector()->testBuildClientConfig($config, '127.0.0.1', 6380)['persistent'])->toBe(30);
+
+    RedisSentinelConnector::$forceCoroutineDetection = true;
+
+    expect(clientConfigConnector()->testBuildClientConfig($config, '127.0.0.1', 6380)['persistent'])->toBe(0);
+});

--- a/tests/Unit/Connectors/ClientConfigTest.php
+++ b/tests/Unit/Connectors/ClientConfigTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+
+function clientConfigConnector(): RedisSentinelConnector
+{
+    return new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public function testBuildClientConfig(array $config, string $ip, int $port): array
+        {
+            return $this->buildClientConfig($config, $ip, $port);
+        }
+    };
+}
+
+afterEach(function () {
+    RedisSentinelConnector::$forceCoroutineDetection = false;
+});
+
+test('persistent is preserved for worker-created clients', function () {
+    $connector = clientConfigConnector();
+    $config = ['persistent' => 30, 'timeout' => 1];
+
+    $result = $connector->testBuildClientConfig($config, '127.0.0.1', 6380);
+
+    expect($result['persistent'])->toBe(30);
+});
+
+test('persistent is forced to zero for coroutine-created clients', function () {
+    $connector = clientConfigConnector();
+    RedisSentinelConnector::$forceCoroutineDetection = true;
+
+    $result = $connector->testBuildClientConfig(['persistent' => 30], '127.0.0.1', 6380);
+
+    expect($result['persistent'])->toBe(0);
+});

--- a/tests/Unit/Context/ExecutionContextTest.php
+++ b/tests/Unit/Context/ExecutionContextTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Context\ExecutionContext;
+use Goopil\LaravelRedisSentinel\Tests\Support\FakeContext;
+
+test('execution context exposes a stable storage slot', function () {
+    $context = new ExecutionContext;
+
+    expect($context->storage())->toBe($context->storage());
+});
+
+test('execution context is not in a coroutine without swoole', function () {
+    expect(ExecutionContext::inCoroutine())->toBeFalse();
+});
+
+test('fake context can switch between slots', function () {
+    $context = new FakeContext;
+    $a = $context->storage();
+
+    $context->use('b');
+
+    expect($context->storage())->not->toBe($a)
+        ->and($context->currentSlot())->toBe('b');
+});

--- a/tests/Unit/RedisSentinelManagerTest.php
+++ b/tests/Unit/RedisSentinelManagerTest.php
@@ -74,6 +74,21 @@ test('resolveConnector returns the correct connector', function () {
     expect($manager->resolveConnector('default'))->toBe($connector);
 });
 
+test('sentinel resolution throws ConfigurationException when no connector is registered for the driver', function () {
+    $config = [
+        'default' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => [
+                'host' => '127.0.0.1',
+                'service' => 'master',
+            ],
+        ],
+    ];
+
+    $manager = new RedisSentinelManager(null, 'phpredis', $config);
+    $manager->resolveConnector('default');
+})->throws(ConfigurationException::class, 'No connector registered for the [phpredis-sentinel] driver.');
+
 test('resolveConnector does not mutate driver property', function () {
     $config = [
         'default' => [

--- a/tests/Unit/RedisSentinelManagerTest.php
+++ b/tests/Unit/RedisSentinelManagerTest.php
@@ -4,6 +4,9 @@ use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
 use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
 use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
 use Goopil\LaravelRedisSentinel\RedisSentinelManager;
+use Illuminate\Contracts\Redis\Connector;
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\RedisManager;
 use Laravel\Horizon\Connectors\RedisConnector;
 
 test('resolveConnector throws InvalidArgumentException if clusters are defined', function () {
@@ -98,6 +101,62 @@ test('resolveConnector does not mutate driver property', function () {
     $manager->resolveConnector('default');
 
     expect($driverProp->getValue($manager))->toBe($originalDriver);
+});
+
+test('resolving a sentinel connection does not mutate the manager driver', function () {
+    $manager = app(RedisSentinelManager::class);
+    $before = (new ReflectionProperty(RedisManager::class, 'driver'))->getValue($manager);
+
+    $manager->connection('phpredis-sentinel');
+
+    $after = (new ReflectionProperty(RedisManager::class, 'driver'))->getValue($manager);
+
+    expect($after)->toBe($before);
+});
+
+test('sentinel resolution never exposes a swapped driver to the registered creator', function () {
+    $config = [
+        'default' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => [
+                'host' => '127.0.0.1',
+                'service' => 'master',
+            ],
+        ],
+    ];
+
+    $manager = new RedisSentinelManager(null, 'phpredis', $config);
+    $driverProp = new ReflectionProperty(RedisManager::class, 'driver');
+
+    $observed = [];
+    $connection = new class extends Connection
+    {
+        public function createSubscription($channels, Closure $callback, $method = 'subscribe') {}
+    };
+    $connector = new class($connection) implements Connector
+    {
+        public function __construct(private readonly Connection $connection) {}
+
+        public function connect(array $config, array $options)
+        {
+            return $this->connection;
+        }
+
+        public function connectToCluster(array $config, array $clusterOptions, array $options)
+        {
+            return $this->connection;
+        }
+    };
+
+    $manager->extend('phpredis-sentinel', function () use ($manager, $driverProp, &$observed, $connector) {
+        $observed[] = $driverProp->getValue($manager);
+
+        return $connector;
+    });
+
+    expect($manager->resolveConnector('default'))->toBe($connector)
+        ->and($manager->resolve('default'))->toBe($connection)
+        ->and($observed)->each->toBe('phpredis');
 });
 
 if (class_exists(RedisConnector::class)) {


### PR DESCRIPTION
## Context

An external architecture review flagged a P1 concurrency bug affecting Swoole/OpenSwoole (Octane) deployments (#66): `RedisSentinelConnection` holds its read/write routing state — per-command client swap, replica stickiness, transaction level — as shared mutable state on a singleton connection. Under cooperative scheduling, two coroutines interleaving commands on the same connection could have one coroutine's reads served by another coroutine's client, reintroducing stale reads after writes.

## Solution

Introduce per-execution-context state (`src/Context/`): each coroutine (or worker process, for FPM/CLI/Octane workers) owns its master/replica clients, stickiness and transaction level, while non-split mode keeps the shared constructor client (FPM parity, no extra connections).

- `ExecutionContext` / `ConnectionContext` / `ConnectionState` primitives; a `CoroutineContextException` fails fast if a coroutine runtime returns unexpected storage instead of silently sharing worker state.
- `RedisSentinelConnection` routes routing state through the current context; the `$this->client` swap is confined to a single-read window so Laravel's own `pipeline()`/`transaction()` (which call `client()`) route MULTI/EXEC to the right per-context master.
- Coroutine-created clients never use phpredis persistent sockets (the persistent table is process-wide and would reintroduce response interleaving).
- `RedisSentinelManager` resolves the sentinel connector without mutating the shared `$driver` property, so concurrent resolutions never observe a swapped driver.
- README Octane section and AGENTS.md document the new architecture.

Non-split mode behavior is unchanged.

## Tests

- 555 passed / 10 skipped (chaos tests require the toxiproxy overlay); 10/10 chaos tests pass with the overlay up.
- `composer lint` green; total coverage 94.9%, patch coverage 100%.

Fixes #66
