### PR TITLE
fix: keep operational command families off the replicas

### DIFF
--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -84,7 +84,7 @@ class RedisSentinelConnection extends PhpRedisConnection
         'zcard', 'zcount', 'zlexcount', 'zrange', 'zrank', 'zrevrange', 'zrevrank', 'zscore', 'zscan',
         'zrangebyscore', 'zrevrangebyscore', 'zrangebylex', 'zrevrangebylex',
         'exists', 'scan', 'type', 'pttl', 'ttl',
-        'object', 'latency', 'memory', 'client', 'debug', 'cluster',
+        'object',
     ];
 
     /** @var array<int, string>|null */

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -74,11 +74,6 @@ function readOnlyCommandDataset(): array
         'pttl' => ['pttl', ['foo'], 1000],
         'ttl' => ['ttl', ['foo'], 60],
         'object' => ['object', ['encoding', 'foo'], 'raw'],
-        'latency' => ['latency', ['history'], []],
-        'memory' => ['memory', ['usage', 'foo'], 100],
-        'client' => ['client', ['list'], []],
-        'debug' => ['debug', ['object', 'foo'], 'debug info'],
-        'cluster' => ['cluster', ['countkeysinslot', 0], 0],
     ];
 }
 
@@ -109,6 +104,23 @@ test('it classifies exposed read-only commands as replica-safe', function (strin
 
     expect($connection->command($command, $parameters))->toBe($result);
 })->with(readOnlyCommandDataset());
+
+test('operational or mutating subcommands of removed families stay on the master', function (string $command, array $parameters, mixed $result) {
+    $masterClient = Mockery::mock(Redis::class);
+    $replicaClient = Mockery::mock(Redis::class);
+
+    $replicaClient->shouldNotReceive($command);
+    $masterClient->expects($command)->with(...$parameters)->once()->andReturn($result);
+
+    $connection = redisSentinelConnection($masterClient, $replicaClient);
+
+    expect($connection->command($command, $parameters))->toBe($result);
+})->with([
+    'client kill' => ['client', ['kill', HOST_1.':6380'], 1],
+    'latency reset' => ['latency', ['reset'], 0],
+    'memory purge' => ['memory', ['purge'], true],
+    'debug reload' => ['debug', ['reload'], 'OK'],
+]);
 
 test('getReadClient falls back to the master client when no replica is configured', function () {
     $masterClient = Mockery::mock(Redis::class);


### PR DESCRIPTION
## Context

#92 (P1, external review): the read/write router matches only the first word of a command, but `READ_ONLY_COMMAND` included whole families (`latency`, `memory`, `client`, `debug`, `cluster`) that contain mutating or operational subcommands. With `read_only_replicas: true`, commands like `CLIENT KILL`, `MEMORY PURGE`, `LATENCY RESET` and `DEBUG RELOAD` executed on replicas — and `CLIENT KILL` could kill the replica connection the app itself uses.

## Solution

- Remove `latency`, `memory`, `client`, `debug`, `cluster` from `READ_ONLY_COMMAND` (keep `object`: all its subcommands are reads). Subcommand-aware routing is deliberately not implemented (YAGNI until someone needs per-subcommand routing); the conservative direction now matches the README, which already documented these families as not routed.
- `ReadWriteSplittingTest`: drop the 5 families from the replica-safe dataset (the dataset/constant invariant test keeps both sides in sync) and pin the new behavior — mutating subcommands route to the master.

Fixes #92
