### PR TITLE
fix: never replay non-transport exceptions thrown inside retried code

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ layer applies to every command, so a non-idempotent write (`INCR`, `LPUSH`, `RPU
 up to `retry.redis.attempts + 1` times on a flapping connection — duplicated queue jobs, doubled counters (Laravel
 does not deduplicate jobs by content).
 
+Only phpredis transport failures (`RedisException`) are candidates for a retry. Any other exception — including one
+thrown by your `transaction()`/`pipeline()` callback (a database error, a domain exception) — propagates immediately
+and its callback is never replayed, even when its message coincidentally matches a configured retry fragment.
+
 Make write paths resilient to re-execution:
 
 - prefer idempotent commands where the semantics allow it (`SET` over `INCR`, `SET ... NX`, ...);

--- a/src/Concerns/Retryable.php
+++ b/src/Concerns/Retryable.php
@@ -4,6 +4,7 @@ namespace Goopil\LaravelRedisSentinel\Concerns;
 
 use Illuminate\Support\Str;
 use Random\RandomException;
+use RedisException;
 use Throwable;
 
 trait Retryable
@@ -47,6 +48,16 @@ trait Retryable
     }
 
     /**
+     * Only phpredis transport failures are retryable by default: any other
+     * Throwable — e.g. an exception raised inside a user callback — must
+     * propagate immediately instead of being replayed (#91).
+     */
+    protected function isRetryableException(Throwable $exception): bool
+    {
+        return $exception instanceof RedisException;
+    }
+
+    /**
      * @throws Throwable
      */
     protected function retryOnFailure(
@@ -67,7 +78,7 @@ trait Retryable
 
                 return $result;
             } catch (Throwable $exception) {
-                if (empty($this->retryMessages) || ! Str::contains($exception->getMessage(), $this->retryMessages, ignoreCase: true)) {
+                if (! $this->isRetryableException($exception) || empty($this->retryMessages) || ! Str::contains($exception->getMessage(), $this->retryMessages, ignoreCase: true)) {
                     throw $exception;
                 }
 

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -379,6 +379,17 @@ class RedisSentinelConnector extends PhpRedisConnector
         );
     }
 
+    /**
+     * Sentinel resolution failures surface as a ConfigurationException wrapping
+     * the transport cause; the connector only ever retries its own wrapped
+     * failures (no user callback crosses this path), so the message-based
+     * contract keeps applying to every Throwable here.
+     */
+    protected function isRetryableException(Throwable $exception): bool
+    {
+        return true;
+    }
+
     private function guardSentinelResolution(): void
     {
         if (self::$breakerOpenedAt === null) {

--- a/tests/Unit/Concerns/LoggableSwallowTest.php
+++ b/tests/Unit/Concerns/LoggableSwallowTest.php
@@ -5,6 +5,7 @@ namespace Goopil\LaravelRedisSentinel\Tests\Unit\Concerns;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
 use Goopil\LaravelRedisSentinel\Concerns\Retryable;
 use Illuminate\Support\Facades\Log;
+use RedisException;
 use ReflectionProperty;
 use RuntimeException;
 
@@ -90,7 +91,7 @@ test('a logging outage cannot break the retry loop', function () {
                 $this->log('attempt '.$this->callCount);
 
                 if ($this->callCount <= 2) {
-                    throw new RuntimeException('connection lost');
+                    throw new RedisException('connection lost');
                 }
 
                 return 'success';

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -139,3 +139,30 @@ test('a retried scan restarts its cursor on the refreshed client', function () {
 
     expect($connection->scan(5))->toBe([null, ['key1']]);
 });
+
+test('a non-transport exception thrown inside transaction() is never replayed', function () {
+    Event::fake();
+
+    $master = Mockery::mock(Redis::class);
+    $master->expects('multi')->once()->andReturnSelf();
+    $master->expects('exec')->never();
+
+    $calls = 0;
+    $connection = new RedisSentinelConnection($master, fn () => $master, []);
+    $connection->setRetryLimit(5);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(['went away']);
+
+    try {
+        $connection->transaction(function () use (&$calls): void {
+            $calls++;
+            throw new RuntimeException('MySQL server has gone away');
+        });
+        $this->fail('RuntimeException was not thrown.');
+    } catch (RuntimeException $exception) {
+        expect($exception->getMessage())->toBe('MySQL server has gone away');
+    }
+
+    expect($calls)->toBe(1)
+        ->and(Event::assertDispatchedTimes(RedisSentinelConnectionFailed::class, 0))->toBeNull();
+});

--- a/tests/Unit/Stubs/RetryableTestException.php
+++ b/tests/Unit/Stubs/RetryableTestException.php
@@ -2,9 +2,9 @@
 
 namespace Goopil\LaravelRedisSentinel\Tests\Unit\Stubs;
 
-use RuntimeException;
+use RedisException;
 
-class RetryableTestException extends RuntimeException
+class RetryableTestException extends RedisException
 {
     public function __construct(string $message = 'retryable error', int $code = 0, ?\Throwable $previous = null)
     {


### PR DESCRIPTION
## Context

#91 (P1, external review): `Retryable::retryOnFailure()` matched retry fragments against **any** `Throwable`. For `transaction()`/`pipeline()`, an exception thrown by the **user callback** is indistinguishable from a transport error: a `QueryException` from MySQL ("MySQL server has gone away") matched the shipped `'went away'` fragment and the whole callback was replayed — doubling application side effects.

## Solution

Introduce a retryability gate in the retry loop:

- `Retryable::isRetryableException()` — base implementation retries **only** phpredis transport failures (`RedisException`). Any other `Throwable` (database error, domain exception thrown by a callback) propagates immediately, never replayed, even when its message matches a configured fragment.
- `RedisSentinelConnector` overrides the gate to `true`: Sentinel resolution failures surface as a `ConfigurationException` wrapping the transport cause, and no user code crosses the connector's retry paths — the message-based outage retry contract (shipped since #63) is preserved.
- The residual EXEC-lost risk (a connection dropped after EXEC was sent) is unchanged and already documented in the README, which now also documents the type gate.

Tests: a business exception inside `transaction()` is never replayed (new unit test, callback invoked exactly once, no failure events); transport `RedisException` retries are unchanged (existing unit + feature + chaos suite green).

Fixes #91
