### PR TITLE
fix: key the Sentinel resolution breaker by cluster

### DIFF
--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -40,11 +40,14 @@ class RedisSentinelConnector extends PhpRedisConnector
 
     private const BREAKER_COOLDOWN_SECONDS = 5.0;
 
-    private static int $resolutionFailures = 0;
-
-    private static ?float $breakerOpenedAt = null;
-
-    private static ?Throwable $breakerLastException = null;
+    /**
+     * Per-cluster Sentinel resolution breaker state, keyed by node cache key
+     * (service + Sentinel endpoints): one cluster's outage must never block
+     * another cluster's resolution. An absent entry means the breaker is closed.
+     *
+     * @var array<string, array{failures: int, openedAt: ?float, lastException: ?Throwable}>
+     */
+    private static array $resolutionBreakers = [];
 
     /**
      * Test-only seam: forces the coroutine branch of buildClientConfig() without
@@ -116,21 +119,23 @@ class RedisSentinelConnector extends PhpRedisConnector
             throw new ConfigurationException(sprintf("No service name has been specified for the Redis Sentinel connection '%s'.", $name));
         }
 
-        $this->guardSentinelResolution();
+        $key = $this->getNodeCacheKey($config);
+
+        $this->guardSentinelResolution($key);
 
         return $this->retryOnFailure(
-            function () use ($config) {
-                $this->guardSentinelResolution();
+            function () use ($config, $key) {
+                $this->guardSentinelResolution($key);
 
                 try {
                     $instance = $this->connectToSentinel($config);
                 } catch (Throwable $e) {
-                    $this->recordSentinelFailure($e);
+                    $this->recordSentinelFailure($key, $e);
 
                     throw $e;
                 }
 
-                $this->recordSentinelSuccess();
+                $this->recordSentinelSuccess($key);
 
                 return $instance;
             },
@@ -209,22 +214,24 @@ class RedisSentinelConnector extends PhpRedisConnector
             return $master;
         }
 
-        $this->guardSentinelResolution();
+        $key = $this->getNodeCacheKey($config);
+
+        $this->guardSentinelResolution($key);
 
         ['ip' => $ip, 'port' => $port] = $this->retryOnFailure(
-            function () use ($config, $service) {
-                $this->guardSentinelResolution();
+            function () use ($config, $service, $key) {
+                $this->guardSentinelResolution($key);
 
                 try {
                     if ($master = $this->connectToSentinel($config)->master($service)) {
-                        $this->recordSentinelSuccess();
+                        $this->recordSentinelSuccess($key);
 
                         return $master;
                     }
 
                     throw new RedisException(sprintf("No master found for service '%s'.", $service));
                 } catch (Throwable $e) {
-                    $this->recordSentinelFailure($e);
+                    $this->recordSentinelFailure($key, $e);
 
                     throw $e;
                 }
@@ -255,11 +262,13 @@ class RedisSentinelConnector extends PhpRedisConnector
         $replicas = $this->masterCache->getReplicas($this->getNodeCacheKey($config));
 
         if (empty($replicas)) {
-            $this->guardSentinelResolution();
+            $key = $this->getNodeCacheKey($config);
+
+            $this->guardSentinelResolution($key);
 
             $slaves = $this->retryOnFailure(
-                function () use ($config, $service) {
-                    $this->guardSentinelResolution();
+                function () use ($config, $service, $key) {
+                    $this->guardSentinelResolution($key);
 
                     try {
                         $result = $this->connectToSentinel($config)->slaves($service);
@@ -268,11 +277,11 @@ class RedisSentinelConnector extends PhpRedisConnector
                             throw new RedisException(sprintf("No replicas found for service '%s'.", $service));
                         }
 
-                        $this->recordSentinelSuccess();
+                        $this->recordSentinelSuccess($key);
 
                         return $result;
                     } catch (Throwable $e) {
-                        $this->recordSentinelFailure($e);
+                        $this->recordSentinelFailure($key, $e);
 
                         throw $e;
                     }
@@ -390,24 +399,28 @@ class RedisSentinelConnector extends PhpRedisConnector
         return true;
     }
 
-    private function guardSentinelResolution(): void
+    private function guardSentinelResolution(string $key): void
     {
-        if (self::$breakerOpenedAt === null) {
+        $breaker = self::$resolutionBreakers[$key] ?? null;
+
+        if ($breaker === null || $breaker['openedAt'] === null) {
             return;
         }
 
-        if ((microtime(true) - self::$breakerOpenedAt) >= self::BREAKER_COOLDOWN_SECONDS) {
-            self::$breakerOpenedAt = null;
-            self::$resolutionFailures = 0;
-            self::$breakerLastException = null;
+        if ((microtime(true) - $breaker['openedAt']) >= self::BREAKER_COOLDOWN_SECONDS) {
+            unset(self::$resolutionBreakers[$key]);
 
             return;
         }
 
-        throw self::$breakerLastException;
+        $lastException = $breaker['lastException'];
+
+        if ($lastException !== null) {
+            throw $lastException;
+        }
     }
 
-    private function recordSentinelFailure(Throwable $exception): void
+    private function recordSentinelFailure(string $key, Throwable $exception): void
     {
         // Only Sentinel unreachability (connectToSentinel exhausting all hosts) opens the breaker;
         // a reachable Sentinel that has no master/replicas for the service is not a Sentinel outage.
@@ -415,19 +428,20 @@ class RedisSentinelConnector extends PhpRedisConnector
             return;
         }
 
-        self::$resolutionFailures++;
-        self::$breakerLastException = $exception;
+        $breaker = self::$resolutionBreakers[$key] ?? ['failures' => 0, 'openedAt' => null, 'lastException' => null];
+        $breaker['failures']++;
+        $breaker['lastException'] = $exception;
 
-        if (self::$resolutionFailures >= self::BREAKER_THRESHOLD) {
-            self::$breakerOpenedAt = microtime(true);
+        if ($breaker['failures'] >= self::BREAKER_THRESHOLD) {
+            $breaker['openedAt'] = microtime(true);
         }
+
+        self::$resolutionBreakers[$key] = $breaker;
     }
 
-    private function recordSentinelSuccess(): void
+    private function recordSentinelSuccess(string $key): void
     {
-        self::$resolutionFailures = 0;
-        self::$breakerOpenedAt = null;
-        self::$breakerLastException = null;
+        unset(self::$resolutionBreakers[$key]);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,11 +26,9 @@ class TestCase extends Orchestra
         }
 
         // Reset the Sentinel resolution breaker between tests (static connector state)
-        foreach (['resolutionFailures' => 0, 'breakerOpenedAt' => null, 'breakerLastException' => null] as $property => $value) {
-            $reflection = new ReflectionProperty(RedisSentinelConnector::class, $property);
-            $reflection->setAccessible(true);
-            $reflection->setValue(null, $value);
-        }
+        $breakers = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionBreakers');
+        $breakers->setAccessible(true);
+        $breakers->setValue(null, []);
 
         // Load workbench routes
         $this->loadWorkbenchRoutes($app);

--- a/tests/Unit/Connectors/NodeAddressCacheIsolationTest.php
+++ b/tests/Unit/Connectors/NodeAddressCacheIsolationTest.php
@@ -4,14 +4,9 @@ use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
 use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
 
 beforeEach(function () {
-    foreach (['resolutionFailures', 'breakerOpenedAt', 'breakerLastException'] as $property) {
-        $ref = new ReflectionProperty(RedisSentinelConnector::class, $property);
-        $ref->setAccessible(true);
-        $ref->setValue(null, match ($property) {
-            'resolutionFailures' => 0,
-            default => null,
-        });
-    }
+    $ref = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionBreakers');
+    $ref->setAccessible(true);
+    $ref->setValue(null, []);
 });
 
 function isolatedConnector(): RedisSentinelConnector

--- a/tests/Unit/Connectors/SentinelBreakerTest.php
+++ b/tests/Unit/Connectors/SentinelBreakerTest.php
@@ -77,9 +77,12 @@ test('breaker closes after the cooldown and a full resolution cycle runs again',
 
     expect($calls)->toBe(2);
 
-    $openedAt = new ReflectionProperty(RedisSentinelConnector::class, 'breakerOpenedAt');
+    $openedAt = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionBreakers');
     $openedAt->setAccessible(true);
-    $openedAt->setValue(null, microtime(true) - 10.0);
+    $state = $openedAt->getValue();
+    $key = array_key_first($state);
+    $state[$key]['openedAt'] = microtime(true) - 10.0;
+    $openedAt->setValue(null, $state);
 
     try {
         $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
@@ -98,8 +101,29 @@ test('a successful resolution resets the breaker counter', function () {
     expect($master)->toBeArray()
         ->and($calls)->toBe(2);
 
-    $failures = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionFailures');
+    $failures = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionBreakers');
     $failures->setAccessible(true);
 
-    expect($failures->getValue())->toBe(0);
+    expect($failures->getValue())->toBe([]);
+});
+
+test('a cluster outage does not block other clusters', function () {
+    $calls = 0;
+    $connector = breakerConnector($calls);
+
+    // Trip the breaker on cluster A (127.0.0.1 endpoints)
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => BREAKER_TEST_HOST]]);
+    } catch (Throwable) {
+    }
+
+    expect($calls)->toBe(2);
+
+    // Cluster B (different Sentinel host) must still attempt a real resolution
+    try {
+        $connector->getMasterAddress(['sentinel' => ['service' => 'master', 'host' => '127.0.0.2']]);
+    } catch (Throwable) {
+    }
+
+    expect($calls)->toBe(4);
 });


### PR DESCRIPTION
## Context

#90 (P1, external review): the Sentinel resolution breaker (failures counter, cooldown, last exception) was `static` on the connector, so it was shared by **every** Sentinel connection in the process. After two failed resolutions on cluster A, cluster C could not reach its own Sentinels for the 5 s cooldown and received **A's** exception — contradicting the package's own multi-cluster design (the node address cache is already namespaced per cluster).

## Solution

Key the breaker state by cluster:

- The 3 statics collapse into one `static array<string, {failures, openedAt, lastException}>` keyed by `getNodeCacheKey()` — the same key (service + sorted Sentinel endpoints) that already isolates the node address cache, so two clusters never share breaker state.
- `guardSentinelResolution()` / `recordSentinelFailure()` / `recordSentinelSuccess()` take the key; an absent entry means the breaker is closed.
- Trigger (`ConfigurationException` only) and cooldown constants unchanged.

Tests: `SentinelBreakerTest` gains a cross-cluster isolation pin (an outage on cluster A does not block cluster B's resolution attempts — cluster B still performs real connection attempts); the reflection-based tests follow the new state shape; the per-test reset in `TestCase` and `NodeAddressCacheIsolationTest` reset the keyed map.

Fixes #90
