### PR TITLE
fix: keep the retry loop alive when the reconnect throws

### DIFF
--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -184,6 +184,26 @@ class RedisSentinelConnection extends PhpRedisConnection
     }
 
     /**
+     * Reconnect a client after a failed attempt. A reconnect that throws must
+     * not short-circuit the retry loop: the next attempt rethrows the command
+     * failure and the max-retry bookkeeping can still run (#47).
+     */
+    private function reconnectClient(callable $connector, string $name): ?\Redis
+    {
+        try {
+            return call_user_func($connector, true);
+        } catch (Throwable $reconnectException) {
+            $this->log($name.' - reconnect failed', [
+                'method' => $name,
+                'reason' => $reconnectException->getMessage(),
+                'connection' => $this->name,
+            ], 'error');
+
+            return null;
+        }
+    }
+
+    /**
      * @throws Throwable
      */
     public function scan($cursor, $options = []): mixed
@@ -446,17 +466,21 @@ class RedisSentinelConnection extends PhpRedisConnection
 
                 if ($usedClient !== $state->master && $this->readConnector) {
                     // The failing attempt ran on the read replica - refresh it
-                    $state->read = call_user_func($this->readConnector, true);
-                } else {
+                    $refreshed = $this->reconnectClient($this->readConnector, $name);
+
+                    if ($refreshed !== null) {
+                        $state->read = $refreshed;
+                    }
+                } elseif ($this->masterConnector) {
                     // The failing attempt ran on the master (write or sticky/fallback read)
                     // - refresh it
-                    $newMasterClient = $this->masterConnector
-                        ? call_user_func($this->masterConnector, true)
-                        : $this->initialMaster;
+                    $refreshed = $this->reconnectClient($this->masterConnector, $name);
 
-                    $state->master = $newMasterClient;
-                    $this->initialMaster = $newMasterClient;
-                    $this->client = $newMasterClient;
+                    if ($refreshed !== null) {
+                        $state->master = $refreshed;
+                        $this->initialMaster = $refreshed;
+                        $this->client = $refreshed;
+                    }
                 }
 
                 $this->log($name.' - retry', [

--- a/tests/Feature/Toxiproxy/RetryAndReconnectTest.php
+++ b/tests/Feature/Toxiproxy/RetryAndReconnectTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionFailed;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionMaxRetryFailed;
 use Illuminate\Support\Facades\Event;
 
 describe('Retries and reconnections under network faults', function () {
@@ -53,11 +54,10 @@ describe('Retries and reconnections under network faults', function () {
     });
 
     test('master outage surfaces the connection failure event and exception then recovers', function () {
-        // With the master proxy disabled, the mandatory reconnect inside the retry
-        // onFail hook throws before onMaxFail can run, so no MaxRetryFailed event
-        // can fire: the per-attempt failure event is the genuine proof that a retry
-        // was attempted during the outage
-        Event::fake([RedisSentinelConnectionFailed::class]);
+        // The mandatory reconnect inside the retry onFail hook is swallowed when
+        // the master stays unreachable, so the retry loop runs to exhaustion and
+        // both the per-attempt failure event and the max-retry event fire
+        Event::fake([RedisSentinelConnectionFailed::class, RedisSentinelConnectionMaxRetryFailed::class]);
 
         config()->set('phpredis-sentinel.retry.redis.attempts', 2);
         config()->set('phpredis-sentinel.retry.sentinel.attempts', 2);
@@ -96,6 +96,7 @@ describe('Retries and reconnections under network faults', function () {
 
         expect(fn () => $connection->set('chaos_max_retry', 'x'))->toThrow(RedisException::class);
         Event::assertDispatched(RedisSentinelConnectionFailed::class);
+        Event::assertDispatched(RedisSentinelConnectionMaxRetryFailed::class);
 
         $this->toxiproxy->enable($masterProxy);
         $this->waitForProxyReady($this->connectedMasterPort());

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -2,6 +2,7 @@
 
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionFailed;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionMaxRetryFailed;
 use Goopil\LaravelRedisSentinel\Tests\Support\FakeContext;
 use Illuminate\Support\Facades\Event;
 
@@ -138,6 +139,32 @@ test('a retried scan restarts its cursor on the refreshed client', function () {
     $connection->setRetryMessages(['broken pipe']);
 
     expect($connection->scan(5))->toBe([null, ['key1']]);
+});
+
+test('a failed reconnect does not short-circuit the max-retry bookkeeping', function () {
+    Event::fake();
+
+    $dead = Mockery::mock(Redis::class);
+    $dead->expects('get')->with('foo')->twice()->andThrow(new RedisException('connection lost'));
+
+    $connection = new RedisSentinelConnection(
+        $dead,
+        fn () => throw new RedisException('master is unreachable, cannot reconnect'),
+        [],
+    );
+    $connection->setRetryLimit(1);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(['connection lost']);
+
+    try {
+        $connection->get('foo');
+        $this->fail('RedisException was not thrown.');
+    } catch (RedisException $exception) {
+        expect($exception->getMessage())->toBe('connection lost');
+    }
+
+    Event::assertDispatchedTimes(RedisSentinelConnectionFailed::class, 2);
+    Event::assertDispatchedTimes(RedisSentinelConnectionMaxRetryFailed::class, 1);
 });
 
 test('a non-transport exception thrown inside transaction() is never replayed', function () {


### PR DESCRIPTION
## Summary
- On a failed attempt, refresh the replica/master through a new `reconnectClient()` helper that swallows a throwing reconnect (logs it, returns null) instead of letting the reconnect exception escape `onFail`
- A throwing master connector no longer overwrites `$state->master` / `$this->initialMaster` / `$this->client` with a dead client, so the next retry attempts against a valid client
- The retry loop now reaches the end of its limit on a hard master outage, so `RedisSentinelConnectionMaxRetryFailed` actually fires (#47)

## Testing
- New unit test: failed reconnect + `retryLimit: 1` → the command failure surfaces (not the reconnect failure), `RedisSentinelConnectionFailed` dispatched twice, `RedisSentinelConnectionMaxRetryFailed` once
- Chaos test (`RetryAndReconnectTest`, toxiproxy) updated: the master-outage scenario now asserts `RedisSentinelConnectionMaxRetryFailed` is dispatched through a real failover
- Full suite: 567 passed, PHPStan and Pint clean

Fixes #47