### PR TITLE
fix: make event dispatch best-effort so observability cannot break retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -394,16 +394,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@semantic-release/git": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-11.0.1.tgz",
@@ -847,20 +837,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
@@ -992,16 +968,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-highlight": {
@@ -2040,16 +2006,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/index-to-position": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
@@ -2301,13 +2257,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",

--- a/src/Concerns/EmitsWorkerEvents.php
+++ b/src/Concerns/EmitsWorkerEvents.php
@@ -2,30 +2,19 @@
 
 namespace Goopil\LaravelRedisSentinel\Concerns;
 
-use Throwable;
-
 trait EmitsWorkerEvents
 {
     protected function emitSuccessEvent(object $event): void
     {
         // env() keeps "1" as a string, so parse the value instead of comparing to true.
         if (filter_var(config('phpredis-sentinel.commands.events.emit_success'), FILTER_VALIDATE_BOOLEAN)) {
-            // Kubernetes probes must keep their exit code even if a listener throws.
-            try {
-                event($event);
-            } catch (Throwable $e) {
-                report($e);
-            }
+            $this->dispatchSafely($event);
         }
     }
 
     protected function emitFailureEvent(object $event): void
     {
         // Kubernetes probes must keep their exit code even if a listener throws.
-        try {
-            event($event);
-        } catch (Throwable $e) {
-            report($e);
-        }
+        $this->dispatchSafely($event);
     }
 }

--- a/src/Concerns/Loggable.php
+++ b/src/Concerns/Loggable.php
@@ -42,11 +42,42 @@ trait Loggable
                 self::$swallowedLogNotified = true;
 
                 error_log(sprintf(
-                    '[laravel-redis-sentinel] logging is failing (%s); retry/failover telemetry is being dropped. Original message: %s',
+                    '[laravel-redis-sentinel] logging is failing (%s); retry/failover telemetry may be dropped. Original message: %s',
                     $e->getMessage(),
                     $message
                 ));
             }
+
+            // One retry against a channel that does not depend on the failing
+            // backend, unless stderr itself is the channel that just failed.
+            try {
+                if (config('phpredis-sentinel.log.channel') !== 'stderr') {
+                    Log::channel('stderr')->{$level}(sprintf('[%s] %s', $this->getLogPrefix(), $message), $context);
+                }
+            } catch (Throwable) {
+                // Nothing left to try — the swallow contract stands.
+            }
+        }
+    }
+
+    /**
+     * Dispatch an event without ever breaking the caller: a throwing user listener
+     * must not abort a retry loop or a failover path. Failures are logged (swallow
+     * contract applies) and the flow continues.
+     */
+    protected function dispatchSafely(object $event): void
+    {
+        try {
+            event($event);
+        } catch (Throwable $e) {
+            // A throwing listener is a real bug: feed the exception handler as well,
+            // best-effort, then warn on the swallow-safe channel.
+            try {
+                report($e);
+            } catch (Throwable) {
+            }
+
+            $this->log('event listener failed', ['event' => get_class($event), 'error' => $e->getMessage()], 'error');
         }
     }
 

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -458,7 +458,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 }
             },
             onFail: function ($exception, $attempts) use ($name, $isReadOnly, &$usedClient, $onFailExtra) {
-                RedisSentinelConnectionFailed::dispatch($this, $exception, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionFailed($this, $exception, $name, $attempts));
 
                 $onFailExtra?->__invoke();
 
@@ -492,7 +492,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 ], 'error');
             },
             onReconnect: function ($attempts) use ($name) {
-                RedisSentinelConnectionReconnected::dispatch($this, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionReconnected($this, $name, $attempts));
 
                 $this->log($name.' - reconnected', [
                     'method' => $name,
@@ -501,7 +501,7 @@ class RedisSentinelConnection extends PhpRedisConnection
                 ]);
             },
             onMaxFail: function ($exception, $attempts) use ($name) {
-                RedisSentinelConnectionMaxRetryFailed::dispatch($this, $exception, $name, $attempts);
+                $this->dispatchSafely(new RedisSentinelConnectionMaxRetryFailed($this, $exception, $name, $attempts));
 
                 $this->log($name.' - max fail', [
                     'method' => $name,

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -303,7 +303,7 @@ class RedisSentinelConnector extends PhpRedisConnector
 
             if (empty($replicas)) {
                 $this->log('No healthy replica, reads fall back to the master', ['service' => $service, 'replicas' => $slaves], 'warning');
-                RedisSentinelReplicaFallback::dispatch($service, $slaves);
+                $this->dispatchSafely(new RedisSentinelReplicaFallback($service, $slaves));
 
                 return $this->getMasterAddress($config, $refresh);
             }
@@ -565,7 +565,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelFail(string $service, string $method): Closure
     {
         return function ($exception, $attempts) use ($service, $method) {
-            RedisSentinelMasterFailed::dispatch($service, $exception, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterFailed($service, $exception, $method, $attempts));
 
             $this->log($method.' - fail', [
                 'method' => $method,
@@ -579,7 +579,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelReconnect(string $service, string $method): Closure
     {
         return function ($attempts) use ($service, $method) {
-            RedisSentinelMasterReconnected::dispatch($service, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterReconnected($service, $method, $attempts));
 
             $this->log($method.' - reconnected', [
                 'method' => $method,
@@ -592,7 +592,7 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function onSentinelMaxFail(string $service, string $method): Closure
     {
         return function ($exception, $attempts) use ($service, $method) {
-            RedisSentinelMasterMaxRetryFailed::dispatch($service, $exception, $method, $attempts);
+            $this->dispatchSafely(new RedisSentinelMasterMaxRetryFailed($service, $exception, $method, $attempts));
 
             $this->log($method.' - max fail', [
                 'method' => $method,

--- a/tests/Unit/Concerns/LoggableSwallowTest.php
+++ b/tests/Unit/Concerns/LoggableSwallowTest.php
@@ -5,6 +5,7 @@ namespace Goopil\LaravelRedisSentinel\Tests\Unit\Concerns;
 use Goopil\LaravelRedisSentinel\Concerns\Loggable;
 use Goopil\LaravelRedisSentinel\Concerns\Retryable;
 use Illuminate\Support\Facades\Log;
+use Mockery;
 use RedisException;
 use ReflectionProperty;
 use RuntimeException;
@@ -26,7 +27,8 @@ test('a swallowed logging failure emits exactly one error_log notice when enable
             'phpredis-sentinel.log.notify_swallowed' => true,
         ]);
 
-        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stack')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stderr')->twice()->andThrow(new RuntimeException('stderr backend down'));
 
         $obj = new LoggableTestObject;
         $obj->testLog('test message');
@@ -54,7 +56,8 @@ test('swallowed logging failures stay silent when the notice is disabled', funct
             'phpredis-sentinel.log.notify_swallowed' => false,
         ]);
 
-        Log::shouldReceive('channel')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stack')->twice()->andThrow(new RuntimeException('log backend down'));
+        Log::shouldReceive('channel')->with('stderr')->twice()->andThrow(new RuntimeException('stderr backend down'));
 
         $obj = new LoggableTestObject;
         $obj->testLog('test message');
@@ -75,7 +78,50 @@ test('a logging outage cannot break the retry loop', function () {
         'phpredis-sentinel.log.notify_swallowed' => true,
     ]);
 
-    Log::shouldReceive('channel')->andThrow(new RuntimeException('log backend down'));
+    Log::shouldReceive('channel')->with('stack')->andThrow(new RuntimeException('log backend down'));
+
+    // When the configured channel is down, the safe-channel retry must deliver
+    // the entry to the 'stderr' channel instead of dropping it.
+    $stderr = Mockery::mock();
+    $stderr->shouldReceive('info')->atLeast()->once()->with(Mockery::pattern('/attempt/'), []);
+
+    Log::shouldReceive('channel')->with('stderr')->andReturn($stderr);
+
+    $obj = new class
+    {
+        use Loggable;
+        use Retryable;
+
+        public int $callCount = 0;
+
+        public function run(): string
+        {
+            return $this->retryOnFailure(function () {
+                $this->callCount++;
+                $this->log('attempt '.$this->callCount);
+
+                if ($this->callCount <= 2) {
+                    throw new RedisException('connection lost');
+                }
+
+                return 'success';
+            });
+        }
+
+        protected function sleepWithBackoff(int $attempt): void {}
+    };
+
+    $obj->setRetryMessages(['connection lost']);
+
+    expect($obj->run())->toBe('success')
+        ->and($obj->callCount)->toBe(3);
+});
+
+test('even the stderr fallback failing cannot break the retry loop', function () {
+    config(['phpredis-sentinel.log.channel' => 'stack']);
+
+    Log::shouldReceive('channel')->with('stack')->andThrow(new RuntimeException('log backend down'));
+    Log::shouldReceive('channel')->with('stderr')->andThrow(new RuntimeException('stderr down too'));
 
     $obj = new class
     {

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -44,6 +44,29 @@ test('a dynamic command that succeeds after one failure returns its result', fun
         ->and(Event::assertDispatchedTimes(RedisSentinelConnectionFailed::class, 1))->toBeNull();
 });
 
+test('a throwing listener on the connection fail event does not abort the retry loop', function () {
+    $listenerInvoked = false;
+    Event::listen(RedisSentinelConnectionFailed::class, function () use (&$listenerInvoked): void {
+        $listenerInvoked = true;
+
+        throw new RuntimeException('listener down');
+    });
+
+    $client = Mockery::mock(Redis::class);
+    $client->expects('hset')->twice()->andReturnUsing(
+        fn () => throw new RedisException('broken pipe'),
+        fn () => 1,
+    );
+
+    $connection = new RedisSentinelConnection($client, fn () => $client, []);
+    $connection->setRetryLimit(1);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(['broken pipe']);
+
+    expect($connection->hset('key', 'field', 'value'))->toBe(1)
+        ->and($listenerInvoked)->toBeTrue();
+});
+
 test('a failed sticky read refreshes the master, not the replica', function () {
     Event::fake();
 

--- a/tests/Unit/Events/DispatchSafetyTest.php
+++ b/tests/Unit/Events/DispatchSafetyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Tests\Unit\Events;
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Events\RedisSentinelReplicaFallback;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Redis;
+use RedisSentinel;
+use RuntimeException;
+
+const HOST_1 = '127.0.0.1';
+const HOST_2 = '127.0.0.2';
+
+test('a throwing listener on the replica fallback event does not break the master fallback', function () {
+    $listenerInvoked = false;
+    Event::listen(RedisSentinelReplicaFallback::class, function () use (&$listenerInvoked): void {
+        $listenerInvoked = true;
+
+        throw new RuntimeException('listener down');
+    });
+
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave,disconnected'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1)
+        ->and($listenerInvoked)->toBeTrue();
+});
+
+test('a failing exception handler does not break the dispatch guard either', function () {
+    Event::listen(RedisSentinelReplicaFallback::class, function (): void {
+        throw new RuntimeException('listener down');
+    });
+
+    app()->instance(
+        ExceptionHandler::class,
+        Mockery::mock(ExceptionHandler::class, function ($mock): void {
+            $mock->shouldReceive('report')->once()->andThrow(new RuntimeException('handler down too'));
+        })
+    );
+
+    $sentinelMock = Mockery::mock(RedisSentinel::class);
+    $sentinelMock->shouldReceive('ping')->andReturn(true);
+    $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
+    $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave,disconnected'],
+    ]);
+
+    $connector = new class($sentinelMock) extends RedisSentinelConnector
+    {
+        public function __construct(private $sentinelMock)
+        {
+            parent::__construct(app(NodeAddressCache::class), app('config'));
+        }
+
+        protected function connectToSentinel(array $config): RedisSentinel
+        {
+            return $this->sentinelMock;
+        }
+
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            ['ip' => $ip] = $readOnly
+                ? $this->getReplicaAddress($config, $refresh)
+                : $this->getMasterAddress($config, $refresh);
+
+            $mock = Mockery::mock(Redis::class);
+            $mock->shouldReceive('getHost')->andReturn($ip);
+
+            return $mock;
+        }
+    };
+
+    $connection = $connector->connect([
+        'sentinel' => ['service' => 'mymaster', 'host' => HOST_1],
+        'read_only_replicas' => true,
+    ], []);
+
+    expect($connection->getReadClient()->getHost())->toBe(HOST_1);
+});


### PR DESCRIPTION
## Summary
- Every package dispatch now goes through a `dispatchSafely()` guard (in `Loggable`, which both the connection and the connector already use): a throwing user listener can no longer abort a retry loop or a failover path — the failure is reported best-effort and logged, and the flow continues
- `Loggable::log()` retries once against the safe `stderr` channel when the configured channel fails, so retry/failover telemetry is no longer silently dropped when Redis itself is the log backend (skipped when `stderr` is the failed channel)
- `EmitsWorkerEvents` reuses the same guard instead of its duplicated inline try/catch

## Testing
- New `DispatchSafetyTest`: throwing listener on the replica-fallback event does not break the master fallback; a failing exception handler does not break the dispatch guard either
- New connection test: throwing listener on the connection-fail event does not abort the retry loop (command still retried and succeeds)
- `LoggableSwallowTest` extended: stderr fallback delivers entries when the configured channel is down; both channels failing still cannot break the retry loop
- Full suite: 571 passed, Pint and PHPStan clean

Fixes #58