### PR TITLE
test: bound CI jobs with timeouts and add a chaos convergence barrier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
 
   security-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -335,6 +336,7 @@ jobs:
   tests-valkey:
     needs: [lint]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     name: PHP 8.4 - L12 - Valkey
 
@@ -414,6 +416,7 @@ jobs:
   tests-chaos:
     needs: [lint]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     name: Chaos - real failover via toxiproxy (PHP 8.4 - L12 - R7)
 

--- a/tests/Feature/Toxiproxy/DegradationTest.php
+++ b/tests/Feature/Toxiproxy/DegradationTest.php
@@ -17,10 +17,8 @@ describe('Network degradation toxics', function () {
         }
 
         // The beforeEach resetAll severs Sentinel's monitoring links to the replicas
-        // (they are announced through the proxies), and while Sentinel still flags
-        // them disconnected the connector silently falls back to the master
-        $this->waitForHealthyReplicas();
-
+        // (they are announced through the proxies); bootToxiproxy's convergence
+        // barrier absorbs that before the test body starts
         config()->set('database.redis.phpredis-sentinel.read_only_replicas', true);
         $this->purgeSentinelConnection();
 

--- a/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
+++ b/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
@@ -34,6 +34,10 @@ trait InteractsWithToxiproxy
         }
 
         $this->resetChaosTopology();
+
+        // Convergence barrier: a sibling test's failover or proxy bounce may still
+        // be settling; every test starts from a stable master + healthy replicas.
+        $this->waitForHealthyReplicas();
     }
 
     public function cleanupToxiproxy(): void


### PR DESCRIPTION
## Summary
- Every workflow job now carries a `timeout-minutes` bound (matrix and without-Horizon already had 45; adds 45 to the chaos and Valkey jobs and 15 to security-audit), so a wedged runner can no longer hang a check indefinitely
- The chaos `beforeEach` ends with a convergence barrier: after the proxy reset, it waits for Sentinel to report a stable master plus two healthy replicas, so every test starts from a converged view instead of inheriting a sibling's failover churn
- `DegradationTest`'s manual `waitForHealthyReplicas()` becomes redundant with the central barrier and is removed

Note: issue items 1-2 (dead `ToxiproxyManager::resetProxy()`, unused `ToxiproxyTestCase` scaffolding) were already resolved upstream — neither exists in the codebase anymore.

## Testing
- Chaos suite: 10/10 against the toxiproxy overlay (with the barrier)
- Full suite: 571 passed, Pint and PHPStan clean; workflow YAML validated

Fixes #50