### PR TITLE
ci: add Redis 8 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,7 +92,7 @@ jobs:
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
         laravel: [10, 11, 12, 13]
-        redis: [6, 7]
+        redis: [6, 7, 8]
         exclude:
           - php: 8.5
             laravel: 10

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![PHP Version](https://img.shields.io/badge/PHP-8.2%20%7C%208.3%20%7C%208.4%20%7C%208.5-blue)](https://www.php.net/)
 [![Laravel](https://img.shields.io/badge/Laravel-10%20%7C%2011%20%7C%2012%20%7C%2013-red)](https://laravel.com/)
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/goopil/laravel-redis-sentinel.svg)](https://packagist.org/packages/goopil/laravel-redis-sentinel)
+[![Total Downloads](https://img.shields.io/packagist/dt/goopil/laravel-redis-sentinel.svg)](https://packagist.org/packages/goopil/laravel-redis-sentinel)
 
 A Laravel package that adds Redis Sentinel support through the PhpRedis extension.
 It is intended for high-availability Redis setups and handles failover and read/write splitting
@@ -912,7 +913,7 @@ The package includes a comprehensive GitHub Actions workflow that tests:
 
 - PHP 8.2, 8.3, 8.4, 8.5
 - Laravel 10, 11, 12, 13
-- Redis 6, 7
+- Redis 6, 7, 8
 - Valkey 8 (dedicated `tests-valkey` job)
 - Linting and static analysis before the test matrix
 - Matrix test jobs across isolated Redis Sentinel clusters


### PR DESCRIPTION
## Summary

- Add Redis 8 to the CI matrix (`redis: [6, 7, 8]`). The CI compose is already fully parameterized by `REDIS_VERSION`, so no compose change is needed.
- Add a Packagist total-downloads badge and list Redis 8 in the README CI section.

## Test plan

- The PR's own CI run exercises the new Redis 8 jobs end to end.