### PR TITLE
fix: honor the global read_commands configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ return [
         ],
     ],
 
+    // Global default for commands routed to replicas in read/write splitting
+    // mode (a connection's own read_commands key overrides this list)
+    'read_commands' => [],
+
     'retry' => [
         // Sentinel connection retries
         'sentinel' => [
@@ -210,6 +214,7 @@ return [
 | `log.channel` | Laravel default | Log channel used for retry/failover telemetry |
 | `log.notify_swallowed` | `false` | `error_log()` notice (once per consuming class) when a logging failure is swallowed |
 | `commands.events.emit_success` | `false` | Emit success events for Horizon probe commands; failure events are always emitted |
+| `read_commands` | `[]` | Global default for the replica-safe command list; a connection's own `read_commands` key overrides it |
 | `retry.sentinel.*` / `retry.redis.*` | see above | Retry attempts, delay and retryable error message fragments |
 
 Cache entries are namespaced per Sentinel cluster (service name + sentinel endpoints), so two connections sharing a
@@ -230,7 +235,7 @@ Per-connection settings in `config/database.php`:
 | `sentinel.timeout` | `1` | Sentinel node connect timeout (seconds) |
 | `sentinel.read_timeout` | `60` | Sentinel node read timeout (seconds) |
 | `retry.redis.attempts` / `delay` / `messages` | package defaults | Per-connection retry override |
-| `read_commands` | `[]` | Additional commands routed to replicas when splitting is enabled (see [Replica-Safe Commands](#replica-safe-commands)) |
+| `read_commands` | `[]` | Additional commands routed to replicas when splitting is enabled; overrides the package-wide `read_commands` value (see [Replica-Safe Commands](#replica-safe-commands)) |
 | `options.prefix` | — | phpredis key prefix |
 
 Data-connection timeouts are isolated from Sentinel node timeouts: `sentinel.timeout`/`sentinel.read_timeout` only

--- a/config/phpredis-sentinel.php
+++ b/config/phpredis-sentinel.php
@@ -21,6 +21,8 @@ return [
         ],
     ],
 
+    // Global default for commands routed to replicas in read/write splitting mode.
+    // A connection's own 'read_commands' key overrides this list.
     'read_commands' => [],
 
     'retry' => [

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -76,6 +76,8 @@ class RedisSentinelConnector extends PhpRedisConnector
     public function connect(array $config, array $options): RedisSentinelConnection
     {
         $config = Arr::except($config, 'command_retries');
+        $config['read_commands'] = Arr::get($config, 'read_commands')
+            ?? $this->config->get('phpredis-sentinel.read_commands', []);
 
         $connectionConfig = $this->mergeConnectionOptions($config, $options);
         $connector = fn ($refresh = false) => $this->createClient($connectionConfig, $refresh);

--- a/tests/Unit/Connectors/ReadCommandsResolutionTest.php
+++ b/tests/Unit/Connectors/ReadCommandsResolutionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+
+function readCommandsConnector(): RedisSentinelConnector
+{
+    return new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        protected function createClient(array $config, bool $refresh = false, bool $readOnly = false): Redis
+        {
+            return Mockery::mock(Redis::class);
+        }
+    };
+}
+
+/** @return array<int, string> */
+function readOnlyCommandsOf(RedisSentinelConnection $connection): array
+{
+    return (new ReflectionProperty($connection, 'readOnlyCommands'))->getValue($connection);
+}
+
+test('a connection without read_commands inherits the global package list', function () {
+    config(['phpredis-sentinel.read_commands' => ['CustomRead']]);
+
+    $connection = readCommandsConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+    ], []);
+
+    $commands = readOnlyCommandsOf($connection);
+
+    expect($commands)->toContain('customread');
+    expect($commands)->toContain('get');
+});
+
+test('a per-connection read_commands list overrides the global one', function () {
+    config(['phpredis-sentinel.read_commands' => ['GlobalRead']]);
+
+    $connection = readCommandsConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+        'read_commands' => ['ConnectionRead'],
+    ], []);
+
+    $commands = readOnlyCommandsOf($connection);
+
+    expect($commands)->toContain('connectionread');
+    expect($commands)->not->toContain('globalread');
+    expect($commands)->toContain('get');
+});
+
+test('without configuration the allowlist is the hardcoded default', function () {
+    config(['phpredis-sentinel.read_commands' => null]);
+
+    $connection = readCommandsConnector()->connect([
+        'sentinel' => ['service' => 'master', 'host' => '127.0.0.1'],
+    ], []);
+
+    expect(readOnlyCommandsOf($connection))->toBe(
+        (new ReflectionClass(RedisSentinelConnection::class))->getConstant('READ_ONLY_COMMAND')
+    );
+});


### PR DESCRIPTION
## Summary

The package config file ships a top-level `read_commands` key, but only the per-connection value was ever read, so the global list silently did nothing.

- Resolve the per-connection `read_commands` key with the package-wide value as fallback, mirroring the `retry.*` resolution order (connection overrides global).
- Document the global key in the README (package options table, config dump) and the override precedence in the connection options table.
- Add unit tests covering: inheritance from the global list, per-connection override, and the hardcoded default when unset.

## Test plan

- `vendor/bin/pest tests/Unit/Connectors/ReadCommandsResolutionTest.php` (3 new tests)
- Full suite locally: 579 passed, 2895 assertions