### PR TITLE
fix: initialize connections array so fresh workers never hit null foreach

### DIFF
--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -19,6 +19,13 @@ class RedisSentinelManager extends RedisManager
      */
     protected ?bool $isHorizonContext = null;
 
+    /**
+     * Initialized so connections() always returns an array — some Laravel
+     * versions leave RedisManager::$connections uninitialized, which makes
+     * consumers (e.g. the Octane stickiness reset) crash on fresh workers.
+     */
+    protected $connections = [];
+
     public function resolve($name = null)
     {
         $name = $name ?: 'default';

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -69,7 +69,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
             return;
         }
 
-        foreach ($app->make(RedisSentinelManager::class)->connections() as $connection) {
+        foreach ($app->make(RedisSentinelManager::class)->connections() ?? [] as $connection) {
             if ($connection instanceof RedisSentinelConnection) {
                 $connection->resetStickiness();
             }

--- a/tests/Unit/ProviderLazinessTest.php
+++ b/tests/Unit/ProviderLazinessTest.php
@@ -1,6 +1,15 @@
 <?php
 
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Illuminate\Cache\RedisStore;
+
+test('connections() returns an array on a fresh manager, before any connection is resolved', function () {
+    // Fresh Octane workers fire RequestReceived before any Redis connection is
+    // resolved, and the stickiness reset iterates connections(). Upstream
+    // RedisManager leaves the underlying property uninitialized, which made
+    // connections() return null and the foreach crash.
+    expect(app(RedisSentinelManager::class)->connections())->toBeArray();
+});
 
 test('the provider does not eagerly resolve the cache, queue and session managers', function () {
     // Laravel 10's Testbench skeleton resolves `cache` during boot, independently of this


### PR DESCRIPTION
## Summary

On fresh processes (new Octane workers, fresh artisan runs), `resetAllStickiness()` crashed with `foreach() argument must be of type array|object, null given` at `RedisSentinelServiceProvider.php:72`.

Root cause: `Illuminate\Redis\RedisManager` declares `protected $connections;` without a default, so `connections()` returns `null` until a connection is resolved — and the package's Octane `RequestReceived` listener iterates it before any connection exists on a fresh worker.

- Initialize `$connections = []` in `RedisSentinelManager` (root cause fix; property stays untyped to match the parent declaration).
- Guard the consumer with `?? []` (hardening against upstream drift).
- Regression test: `connections()` returns an array on a fresh manager, before any connection is resolved.

## Test plan

- Regression test in `ProviderLazinessTest` (fresh boot, nothing resolved — the exact fresh-worker scenario).
- Full suite locally: 580 passed, 2896 assertions; lint + phpstan clean.

Fixes the bug reported from real Octane usage.