### PR TITLE
feat: TLS support for Sentinel and data connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ composer.lock
 .superpowers/
 docs/
 .output.txt
+tests/tls/*.key
+tests/tls/*.crt
+tests/tls/*.csr
+tests/tls/*.srl

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tests/tls/*.key
 tests/tls/*.crt
 tests/tls/*.csr
 tests/tls/*.srl
+tests/tls/server.ext

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,13 @@ All Redis services use password `test`. Two compose files exist:
 - `docker-compose.yml` — local dev, hardcoded ports (use this for local testing)
 - `tests/ci/docker-compose.yml` — CI only, ports via env vars, do not call directly
 
+## TLS tests
+
+```bash
+./tests/tls/generate-certs.sh && docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+```
+Adds `tls-main` (Redis TLS :6393) and `tls-sentinel` (Sentinel TLS :26383, monitors `tls-master` over TLS, requires `tls-replication yes`). `tests/Feature/TlsConnectionTest.php` skips when the overlay is down.
+
 ## Chaos tests (toxiproxy)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ managing Sentinel-specific logic.
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Configuration](#configuration)
+- [TLS](#tls)
 - [Read/Write Splitting](#readwrite-splitting)
 - [Usage Examples](#usage-examples)
 - [Laravel Octane Support](#laravel-octane-support)
@@ -238,9 +239,68 @@ Per-connection settings in `config/database.php`:
 | `retry.redis.attempts` / `delay` / `messages` | package defaults | Per-connection retry override |
 | `read_commands` | `[]` | Additional commands routed to replicas when splitting is enabled; overrides the package-wide `read_commands` value (see [Replica-Safe Commands](#replica-safe-commands)) |
 | `options.prefix` | — | phpredis key prefix |
+| `sentinel.ssl` | `null` | SSL stream context options for the Sentinel connections — requires phpredis >= 6.0 (see [TLS](#tls)) |
+| `options.scheme` | — | Data connection scheme passed to phpredis (`tls`, `unix`, ...) |
+| `options.context` | — | Data connection stream context (see [TLS](#tls)) |
 
 Data-connection timeouts are isolated from Sentinel node timeouts: `sentinel.timeout`/`sentinel.read_timeout` only
 affect the Sentinel nodes.
+
+### TLS
+
+TLS is configured **independently** for the Sentinel connections and for the data connections — mixed setups
+(e.g. plaintext Sentinels on a private network, TLS-only Redis nodes) are supported.
+
+**Data connections** (master and read replicas) use the standard Laravel/PhpRedis options:
+
+```php
+'default' => [
+    // ...
+    'options' => [
+        'prefix' => env('REDIS_PREFIX', 'laravel_'),
+        'scheme' => 'tls',
+        'context' => [
+            'stream' => [
+                'cafile' => '/path/to/ca.crt',
+                // any PHP stream SSL option: verify_peer, local_cert, peer_name, ...
+            ],
+        ],
+    ],
+],
+```
+
+**Sentinel connections** use `sentinel.ssl` — an array of PHP SSL stream context options
+(**phpredis >= 6.0** required; a clear `ConfigurationException` is thrown on older versions):
+
+```php
+'default' => [
+    'sentinels' => [
+        ['host' => '10.0.0.1', 'port' => 26379],
+        ['host' => '10.0.0.2', 'port' => 26379],
+        ['host' => '10.0.0.3', 'port' => 26379],
+    ],
+    'sentinel' => [
+        'service' => env('REDIS_SENTINEL_SERVICE'),
+        'ssl' => ['cafile' => '/path/to/ca.crt'],
+        // ['stream' => [...]] and ['ssl' => [...]] wrappers are also accepted
+    ],
+],
+```
+
+Server-side requirements (outside this package's scope):
+
+- your Sentinel must itself listen on TLS (`tls-port`, plus `port 0` for TLS-only);
+- for a TLS-only master, set `tls-replication yes` in the **Sentinel** configuration — this is what makes
+  Sentinel speak TLS to the instances it monitors;
+- Redis validates the peer certificate chain against `tls-ca-cert-file` only (no hostname check by default);
+  issue a dedicated per-cluster CA.
+
+Local TLS test environment (used by `tests/Feature/TlsConnectionTest.php`, which skips when absent):
+
+```bash
+./tests/tls/generate-certs.sh
+docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+```
 
 ### Laravel Redis Binding Override
 
@@ -742,7 +802,7 @@ The default retry configuration is intentionally conservative. Tune it according
 - run Redis and Sentinel on a private network whenever possible;
 - use Redis ACLs or strong passwords for both Redis and Sentinel;
 - inject secrets through environment variables or your secret manager, not committed configuration files;
-- consider TLS, stunnel, sidecars, or a private service mesh if traffic can cross untrusted networks.
+- TLS is supported natively for both data and Sentinel connections — see [TLS](#tls); stunnel, sidecars, or a private service mesh remain options for links that cannot run TLS.
 
 ### What to Monitor
 
@@ -897,6 +957,15 @@ composer stan
 # Fix code style
 composer format
 ```
+
+Local TLS test environment for the TLS feature tests:
+
+```bash
+./tests/tls/generate-certs.sh
+docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+```
+
+`tests/Feature/TlsConnectionTest.php` is skipped automatically when the TLS stack is not running.
 
 ### Test Structure
 

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -1,0 +1,32 @@
+services:
+  tls-main:
+    image: redis:6.2-alpine
+    network_mode: host
+    volumes:
+      - ./tests/tls:/tls:ro
+    command:
+      - redis-server
+      - --port
+      - "0"
+      - --tls-port
+      - "6393"
+      - --tls-cert-file
+      - /tls/server.crt
+      - --tls-key-file
+      - /tls/server.key
+      - --tls-ca-cert-file
+      - /tls/ca.crt
+      - --tls-auth-clients
+      - "no"
+
+  tls-sentinel:
+    image: redis:6.2-alpine
+    network_mode: host
+    depends_on:
+      - tls-main
+    volumes:
+      - ./tests/tls:/tls:ro
+    command:
+      - sh
+      - -c
+      - cp /tls/sentinel-tls.conf /tmp/sentinel.conf && exec redis-server /tmp/sentinel.conf --sentinel

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -352,6 +352,15 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function connectToSentinel(array $config): RedisSentinel
     {
         $sentinels = $this->getSentinels($config);
+        $ssl = $this->resolveSentinelSsl($config);
+
+        if ($ssl !== null && ! $this->needParamsAsArray()) {
+            throw new ConfigurationException(sprintf(
+                'Sentinel TLS (sentinel.ssl) requires the phpredis array-form constructor (phpredis >= 6.0); installed: %s.',
+                (string) phpversion('redis'),
+            ));
+        }
+
         $lastException = null;
 
         foreach ($sentinels as $sentinel) {
@@ -383,6 +392,10 @@ class RedisSentinelConnector extends PhpRedisConnector
 
             if (($password = $config['sentinel']['password'] ?? $config['password'] ?? '') !== '') {
                 $options['auth'] = $password;
+            }
+
+            if ($ssl !== null) {
+                $options['ssl'] = $ssl;
             }
 
             try {
@@ -500,6 +513,38 @@ class RedisSentinelConnector extends PhpRedisConnector
     protected function getService(array $config): ?string
     {
         return $config['sentinel']['service'] ?? $config['service'] ?? null;
+    }
+
+    /**
+     * phpredis applies each top-level key of the RedisSentinel "ssl" option
+     * under the "ssl" stream context section and switches the connection to
+     * TLS; the Laravel-style wrappers are unwrapped so both documented forms
+     * behave identically on the data plane and the Sentinel plane.
+     *
+     * @param  array<string, mixed>  $config
+     * @return array<string, mixed>|null
+     */
+    protected function resolveSentinelSsl(array $config): ?array
+    {
+        $ssl = $config['sentinel']['ssl'] ?? null;
+
+        if ($ssl === null) {
+            return null;
+        }
+
+        if (! is_array($ssl)) {
+            throw new ConfigurationException('The sentinel.ssl option must be an array of SSL stream context options.');
+        }
+
+        if (isset($ssl['stream']) && is_array($ssl['stream'])) {
+            return $ssl['stream'];
+        }
+
+        if (isset($ssl['ssl']) && is_array($ssl['ssl'])) {
+            return $ssl['ssl'];
+        }
+
+        return $ssl;
     }
 
     /**

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -572,7 +572,7 @@ class RedisSentinelConnector extends PhpRedisConnector
      * bundled stubs only declare the positional form, so the array branch is
      * triaged here.
      *
-     * @param  array<string, int|string|null>  $options
+     * @param  array<string, mixed>  $options
      */
     protected function createSentinelInstance(array $options): RedisSentinel
     {

--- a/tests/Feature/TlsConnectionTest.php
+++ b/tests/Feature/TlsConnectionTest.php
@@ -9,7 +9,7 @@ beforeEach(function () {
         $this->markTestSkipped('TLS test certificates not generated (run ./tests/tls/generate-certs.sh).');
     }
 
-    $socket = @fsockopen('127.0.0.1', (int) env('REDIS_SENTINEL_TLS_PORT', 26383), $errno, $errstr, 0.2);
+    $socket = @fsockopen(env('REDIS_SENTINEL_TLS_HOST', '127.0.0.1'), (int) env('REDIS_SENTINEL_TLS_PORT', 26383), $errno, $errstr, 0.2);
 
     if ($socket === false) {
         $this->markTestSkipped('TLS Sentinel not running (docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d).');

--- a/tests/Feature/TlsConnectionTest.php
+++ b/tests/Feature/TlsConnectionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Support\Facades\Redis;
+
+beforeEach(function () {
+    $ca = __DIR__.'/../tls/ca.crt';
+
+    if (! is_file($ca)) {
+        $this->markTestSkipped('TLS test certificates not generated (run ./tests/tls/generate-certs.sh).');
+    }
+
+    $socket = @fsockopen('127.0.0.1', (int) env('REDIS_SENTINEL_TLS_PORT', 26383), $errno, $errstr, 0.2);
+
+    if ($socket === false) {
+        $this->markTestSkipped('TLS Sentinel not running (docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d).');
+    }
+
+    fclose($socket);
+});
+
+test('sentinel resolution and data connection both run over TLS', function () {
+    expect(Redis::connection('phpredis-sentinel-tls'))->toBeAWorkingRedisConnection();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,6 +62,28 @@ class TestCase extends Orchestra
                 ],
             ]);
 
+            $tlsCa = __DIR__.'/tls/ca.crt';
+
+            $config->set('database.redis.phpredis-sentinel-tls', [
+                'client' => 'phpredis-sentinel',
+                'sentinel' => [
+                    'host' => env('REDIS_SENTINEL_TLS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_SENTINEL_TLS_PORT', 26383),
+                    'service' => env('REDIS_SENTINEL_TLS_SERVICE', 'tls-master'),
+                    'ssl' => ['cafile' => $tlsCa],
+                    'timeout' => 1,
+                    'read_timeout' => 1,
+                ],
+                'password' => '',
+                'timeout' => 1,
+                'read_timeout' => 1,
+                'database' => 0,
+                'options' => [
+                    'scheme' => 'tls',
+                    'context' => ['stream' => ['cafile' => $tlsCa]],
+                ],
+            ]);
+
             $config->set('database.redis.redis', [
                 'host' => env('REDIS_HOST', '127.0.0.1'),
                 'password' => env('REDIS_PASSWORD', 'test'),

--- a/tests/Unit/Connectors/ClientConfigTest.php
+++ b/tests/Unit/Connectors/ClientConfigTest.php
@@ -45,3 +45,17 @@ test('sentinel.persistent fallback is preserved for workers and forced to zero i
 
     expect(clientConfigConnector()->testBuildClientConfig($config, '127.0.0.1', 6380)['persistent'])->toBe(0);
 });
+
+test('TLS scheme and stream context from options survive the client config merge', function () {
+    $built = clientConfigConnector()->testBuildClientConfig([
+        'options' => [
+            'scheme' => 'tls',
+            'context' => ['stream' => ['cafile' => '/tmp/ca.crt']],
+        ],
+    ], '10.0.0.1', 6380);
+
+    expect($built['scheme'])->toBe('tls')
+        ->and($built['context'])->toBe(['stream' => ['cafile' => '/tmp/ca.crt']])
+        ->and($built['host'])->toBe('10.0.0.1')
+        ->and($built['port'])->toBe(6380);
+});

--- a/tests/Unit/Connectors/SentinelSslTest.php
+++ b/tests/Unit/Connectors/SentinelSslTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
+
+beforeEach(function () {
+    $breakers = new ReflectionProperty(RedisSentinelConnector::class, 'resolutionBreakers');
+    $breakers->setAccessible(true);
+    $breakers->setValue(null, []);
+});
+
+function sslConnector(): RedisSentinelConnector
+{
+    return new class(app(NodeAddressCache::class), app('config')) extends RedisSentinelConnector
+    {
+        public ?array $capturedOptions = null;
+
+        public function withPhpRedisVersion(string $version): static
+        {
+            (new ReflectionProperty($this, 'phpredisVersion'))->setValue($this, $version);
+
+            return $this;
+        }
+
+        public function testConnectToSentinel(array $config): RedisSentinel
+        {
+            return $this->connectToSentinel($config);
+        }
+
+        protected function createSentinelInstance(array $options): RedisSentinel
+        {
+            $this->capturedOptions = $options;
+
+            $sentinel = Mockery::mock(RedisSentinel::class);
+            $sentinel->shouldReceive('ping')->andReturnTrue();
+
+            return $sentinel;
+        }
+    };
+}
+
+test('sentinel.ssl is passed as a flat ssl option to RedisSentinel', function () {
+    $config = ['sentinel' => [
+        'host' => '127.0.0.1', 'port' => 26379,
+        'ssl' => ['cafile' => '/tmp/ca.crt'],
+    ]];
+
+    $connector = sslConnector()->withPhpRedisVersion('6.0.0');
+    $connector->testConnectToSentinel($config);
+
+    expect($connector->capturedOptions['ssl'])->toBe(['cafile' => '/tmp/ca.crt']);
+});
+
+test('sentinel.ssl accepts the stream wrapper', function () {
+    $config = ['sentinel' => [
+        'host' => '127.0.0.1', 'port' => 26379,
+        'ssl' => ['stream' => ['cafile' => '/tmp/ca.crt']],
+    ]];
+
+    $connector = sslConnector()->withPhpRedisVersion('6.0.0');
+    $connector->testConnectToSentinel($config);
+
+    expect($connector->capturedOptions['ssl'])->toBe(['cafile' => '/tmp/ca.crt']);
+});
+
+test('sentinel.ssl accepts the ssl wrapper', function () {
+    $config = ['sentinel' => [
+        'host' => '127.0.0.1', 'port' => 26379,
+        'ssl' => ['ssl' => ['cafile' => '/tmp/ca.crt']],
+    ]];
+
+    $connector = sslConnector()->withPhpRedisVersion('6.0.0');
+    $connector->testConnectToSentinel($config);
+
+    expect($connector->capturedOptions['ssl'])->toBe(['cafile' => '/tmp/ca.crt']);
+});
+
+test('no ssl option is added when sentinel.ssl is absent', function () {
+    $config = ['sentinel' => ['host' => '127.0.0.1', 'port' => 26379]];
+
+    $connector = sslConnector()->withPhpRedisVersion('6.0.0');
+    $connector->testConnectToSentinel($config);
+
+    expect($connector->capturedOptions)->not->toHaveKey('ssl');
+});
+
+test('sentinel.ssl is rejected on phpredis < 6 (no positional ssl argument)', function () {
+    $config = ['sentinel' => [
+        'host' => '127.0.0.1', 'port' => 26379,
+        'ssl' => ['cafile' => '/tmp/ca.crt'],
+    ]];
+
+    $connector = sslConnector()->withPhpRedisVersion('5.3.9');
+
+    expect(fn () => $connector->testConnectToSentinel($config))
+        ->toThrow(ConfigurationException::class, 'phpredis >= 6.0');
+});
+
+test('a non-array sentinel.ssl is rejected', function () {
+    $config = ['sentinel' => [
+        'host' => '127.0.0.1', 'port' => 26379,
+        'ssl' => 'yes',
+    ]];
+
+    $connector = sslConnector()->withPhpRedisVersion('6.0.0');
+
+    expect(fn () => $connector->testConnectToSentinel($config))
+        ->toThrow(ConfigurationException::class, 'must be an array');
+});

--- a/tests/tls/generate-certs.sh
+++ b/tests/tls/generate-certs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+openssl genrsa -out ca.key 4096 2>/dev/null
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+    -out ca.crt -subj "/CN=laravel-redis-sentinel-test-ca"
+
+openssl genrsa -out server.key 2048 2>/dev/null
+openssl req -new -key server.key -out server.csr -subj "/CN=redis-server"
+
+cat > server.ext <<'EOF'
+subjectAltName = DNS:localhost, IP:127.0.0.1
+extendedKeyUsage = serverAuth, clientAuth
+EOF
+
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+    -out server.crt -days 3650 -sha256 -extfile server.ext 2>/dev/null
+
+rm -f server.csr server.ext ca.srl
+echo "TLS test certificates generated in $(pwd)"

--- a/tests/tls/sentinel-tls.conf
+++ b/tests/tls/sentinel-tls.conf
@@ -1,0 +1,11 @@
+port 0
+tls-port 26383
+tls-cert-file /tls/server.crt
+tls-key-file /tls/server.key
+tls-ca-cert-file /tls/ca.crt
+tls-auth-clients no
+tls-replication yes
+sentinel monitor tls-master 127.0.0.1 6393 1
+sentinel down-after-milliseconds tls-master 2000
+sentinel failover-timeout tls-master 10000
+sentinel parallel-syncs tls-master 1


### PR DESCRIPTION
## Summary

- Add native TLS support for Sentinel connections via a new `sentinel.ssl` option (flat SSL stream-context array; Laravel-style `stream`/`ssl` wrappers also accepted), enforced to require **phpredis >= 6** — a clear `ConfigurationException` is thrown on older versions so TLS can never be silently downgraded to plaintext
- Pin and document TLS on the **data plane** (master + read replicas), which already works through Laravel's native `options.scheme` + `options.context` and is now regression-tested
- Add a complete local TLS test environment: `docker-compose.tls.yml` overlay (`tls-main` :6393, `tls-sentinel` :26383 monitoring `tls-master` over TLS via `tls-replication yes`), self-signed cert generator (`tests/tls/generate-certs.sh`, generated material gitignored), and an end-to-end Pest test (`tests/Feature/TlsConnectionTest.php`) that skips automatically when the overlay is not running
- Document everything in README (new `### TLS` section, Connection Options rows, Security bullet) and AGENTS.md

## Commits

| Commit | Content |
|---|---|
| `df550e8` | `sentinel.ssl` connector option (TDD, 6 unit tests via `createSentinelInstance` seam) |
| `f3009fa` | Data-plane TLS pass-through pin test (`buildClientConfig`) |
| `fc16119` | TLS docker environment (overlay + certs + sentinel conf) |
| `97887b9` | `phpredis-sentinel-tls` TestCase connection + e2e TLS feature test |
| `ed6205a` | README + AGENTS documentation |
| `14799ff` | Skip guard honors `REDIS_SENTINEL_TLS_HOST`; gitignore cert leftovers |

## Test plan

- [x] `vendor/bin/pest tests/Unit/Connectors/SentinelSslTest.php` — 6 tests (flat pass-through, both wrappers, absent option, phpredis < 6 gate, non-array rejection)
- [x] `vendor/bin/pest tests/Feature/TlsConnectionTest.php` — PASS with TLS env up, SKIP when down
- [x] Full suite green (587+) and `composer lint` clean; review also re-ran all 11 TLS-related tests against the live stack (11 passed)
- [x] Verified manually: `redis-cli -p 26383 --tls --cacert tests/tls/ca.crt SENTINEL get-master-addr-by-name tls-master` → `127.0.0.1 6393`

## Notes

- TLS config is independent per plane: mixed setups (plaintext Sentinels + TLS-only Redis nodes) are supported
- Server-side requirement (documented, outside package scope): Sentinel needs `tls-replication yes` to speak TLS to monitored instances (verified against redis 6.2 `sentinel.c`)
- Local note: TLS overlay uses ports 6393/26383 (6390/26381 collide with other local stacks)