### PR TITLE
fix: read horizon liveness service from the documented config schema

### DIFF
--- a/src/Commands/HorizonWorkerLiveness.php
+++ b/src/Commands/HorizonWorkerLiveness.php
@@ -71,7 +71,10 @@ class HorizonWorkerLiveness extends Command
     public function checkSentinel(RedisSentinelManager $manager): int
     {
         $connectionName = config('horizon.use');
-        $service = config(sprintf('database.redis.%s.sentinel.service', $connectionName));
+        // Same resolution order as RedisSentinelConnector::getService():
+        // nested sentinel.service first, then the connection-level key.
+        $service = config(sprintf('database.redis.%s.sentinel.service', $connectionName))
+            ?? config(sprintf('database.redis.%s.service', $connectionName));
         $client = config(
             sprintf('database.redis.%s.client', $connectionName),
             config('database.redis.client')

--- a/tests/Feature/Horizon/Commands/HorizonWorkerLivenessTest.php
+++ b/tests/Feature/Horizon/Commands/HorizonWorkerLivenessTest.php
@@ -13,6 +13,90 @@ beforeEach(function () {
     config(['horizon.use' => 'phpredis-sentinel']);
 });
 
+test('horizon:alive resolves the service from the documented connection-level config', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'service' => 'mymaster',
+            'sentinel' => [
+                'host' => HORIZON_LIVENESS_TEST_HOST,
+                'port' => 26379,
+            ],
+        ],
+    ]);
+
+    $connector = Mockery::mock(RedisSentinelConnector::class);
+    $sentinel = Mockery::mock(RedisSentinel::class);
+    $sentinel->expects('getMasterAddrByName')
+        ->with('mymaster')
+        ->andReturns(['ip' => HORIZON_LIVENESS_TEST_HOST, 'port' => 26379]);
+    $connector->expects('createSentinel')->andReturns($sentinel);
+
+    $manager = Mockery::mock(RedisSentinelManager::class);
+    $manager->allows('resolveConnector')
+        ->with('phpredis-sentinel')
+        ->andReturns($connector);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->allows('setex')->andReturns(true);
+    $manager->allows('resolve')->with('phpredis-sentinel')->andReturns($connection);
+
+    app()->instance(RedisSentinelManager::class, $manager);
+
+    $master = new stdClass;
+    $master->name = MasterSupervisor::basename().'-tst1';
+    $master->status = 'running';
+    $repository = Mockery::mock(MasterSupervisorRepository::class);
+    $repository->allows('all')->andReturns([$master]);
+    app()->instance(MasterSupervisorRepository::class, $repository);
+
+    $status = Artisan::call('horizon:alive');
+
+    expect($status)->toBe(0);
+});
+
+test('horizon:alive still resolves the service from the nested sentinel config', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => [
+                'host' => HORIZON_LIVENESS_TEST_HOST,
+                'port' => 26379,
+                'service' => 'nestedmaster',
+            ],
+        ],
+    ]);
+
+    $connector = Mockery::mock(RedisSentinelConnector::class);
+    $sentinel = Mockery::mock(RedisSentinel::class);
+    $sentinel->expects('getMasterAddrByName')
+        ->with('nestedmaster')
+        ->andReturns(['ip' => HORIZON_LIVENESS_TEST_HOST, 'port' => 26379]);
+    $connector->expects('createSentinel')->andReturns($sentinel);
+
+    $manager = Mockery::mock(RedisSentinelManager::class);
+    $manager->allows('resolveConnector')
+        ->with('phpredis-sentinel')
+        ->andReturns($connector);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->allows('setex')->andReturns(true);
+    $manager->allows('resolve')->with('phpredis-sentinel')->andReturns($connection);
+
+    app()->instance(RedisSentinelManager::class, $manager);
+
+    $master = new stdClass;
+    $master->name = MasterSupervisor::basename().'-tst1';
+    $master->status = 'running';
+    $repository = Mockery::mock(MasterSupervisorRepository::class);
+    $repository->allows('all')->andReturns([$master]);
+    app()->instance(MasterSupervisorRepository::class, $repository);
+
+    $status = Artisan::call('horizon:alive');
+
+    expect($status)->toBe(0);
+});
+
 test('horizon:alive returns 0 when all checks pass', function () {
     // 1. Mock Sentinel check (returns 1 on success)
     $connector = Mockery::mock(RedisSentinelConnector::class);


### PR DESCRIPTION
## Summary

`HorizonWorkerLiveness::checkSentinel()` only read the nested `sentinel.service` key, while the connector's `getService()` (`RedisSentinelConnector.php:502`) also accepts `service` at the **connection level** — the shape the package's own docs show. With a connection-level config:

1. `$service` is `null`
2. `getMasterAddrByName(null)` triggers a PHP 8.5 deprecation (`Passing null to parameter #1 ($master) of type string is deprecated`)
3. `checkSentinel()` returns `1` → `horizon:alive` exits `1` **deterministically**, failover or not

- Resolve the service with the same order as `getService()`: nested `sentinel.service` first, then the connection-level `service` key — so the probe reads exactly the value the connector itself uses.
- No explicit null guard: when no service is configured, `createSentinel()` already throws a precise `ConfigurationException` ("No service name has been specified...") before `getMasterAddrByName()` is reached; the existing catch logs `service: null`.
- Regression tests with **argument-checked** mocks (`with('mymaster')`): the previous suite used argument-agnostic Sentinel mocks, which is why `getMasterAddrByName(null)` was never caught. One test covers the connection-level schema (the bug), one guards the nested schema (backward compat).

## Test plan

- `vendor/bin/pest tests/Feature/Horizon/Commands/HorizonWorkerLivenessTest.php` — new test failed first (status 1), passes after the fix; 8/8 green.
- Full suite locally: 582 passed, 2902 assertions; lint + phpstan clean.

Reported from real Octane/K8s usage with the documented config shape.