### PR TITLE
test: add memory/FD soak test for long-running runtimes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -498,6 +498,7 @@ jobs:
           REDIS_MAIN_PROXY_PORT: 7655
           REDIS_REPLICA1_PROXY_PORT: 7656
           REDIS_REPLICA2_PROXY_PORT: 7657
+          SOAK: '1'
 
       - name: Cleanup chaos stack
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ vendor/bin/pest --group=toxiproxy                                        # run o
 
 The overlay gives Sentinel a quorum of 1, a 5000 ms down-after and a 5000 ms failover-timeout, so cutting the master proxy triggers a real promotion and the post-failover cool-down is only ~10 s (tests may trigger promotions back-to-back). The 5000 ms down-after gives 5x headroom over the worst Sentinel ping-reply jitter observed on Docker Desktop (~1 s); a lower value self-sustains sdown/odown flapping even when idle. Chaos tests skip automatically when the overlay is not running.
 
+`SoakTest.php` (group `soak`, ~20 s) asserts bounded memory/FD growth across 300 uncached `resolve()` calls and 2 forced failovers. It skips unless `SOAK=1` — run via `composer test:soak` or the chaos CI job, never in the default suite.
+
 ## Test wiring
 
 `tests/TestCase.php` defines two connections for comparison testing:

--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,16 @@ vendor/bin/pest --group=toxiproxy
 
 The chaos tests are skipped automatically when the chaos stack is not running.
 
+A soak test (group `soak`) additionally guards the long-running-runtimes failure surface: sustained connection
+churn plus forced failovers must stay within generous memory and file-descriptor growth thresholds, catching
+leaked references on replaced clients that per-command tests cannot see. It skips by default and activates with:
+
+```bash
+composer test:soak
+```
+
+It also runs inside the `tests-chaos` CI job.
+
 ## Local Development
 
 ### Docker Environment

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
         "test:coverage": [
             "@php vendor/bin/pest --coverage --min=70"
         ],
+        "test:soak": [
+            "SOAK=1 @php vendor/bin/pest --group=soak"
+        ],
         "lint": [
             "@php vendor/bin/pint -v --test"
         ],

--- a/tests/Feature/Toxiproxy/SoakTest.php
+++ b/tests/Feature/Toxiproxy/SoakTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
+
+test('sustained connection churn and forced failovers do not leak memory or file descriptors', function () {
+    if (getenv('SOAK') !== '1') {
+        $this->markTestSkipped('Set SOAK=1 to run the soak test (it runs for minutes by design).');
+    }
+
+    if (trim((string) shell_exec('command -v lsof')) === '') {
+        $this->markTestSkipped('lsof is not available on this host.');
+    }
+
+    $fdCount = fn (): int => count(explode("\n", trim((string) shell_exec('lsof -p '.(int) getmypid().' 2>/dev/null'))));
+
+    // Long-lived connection, like a queue worker or an Octane worker: the leak
+    // surface is its reconnect/refresh paths, not its construction.
+    $connection = $this->sentinelConnectionWithRetry();
+
+    // Warmup: lazy allocations (clients, node cache, context state) must not
+    // count as leaks, so the baseline is taken after they settled.
+    for ($i = 0; $i < 100; $i++) {
+        $connection->setex("soak:warmup:{$i}", 120, str_repeat('x', 128));
+        $connection->get("soak:warmup:{$i}");
+    }
+
+    gc_collect_cycles();
+    $memoryBaseline = memory_get_usage();
+    $fdBaseline = $fdCount();
+
+    // Phase 1 — uncached resolves: every call builds a fresh connection with
+    // fresh phpredis clients (the exact path FdLeakTest flags as a leak
+    // candidate). Once unreferenced, the whole object graph must be
+    // reclaimable: held references would show up as unbounded memory/FD growth.
+    $manager = app(RedisSentinelManager::class);
+
+    for ($i = 0; $i < 300; $i++) {
+        $fresh = $manager->resolve('phpredis-sentinel');
+        $fresh->setex("soak:churn:{$i}", 120, "v{$i}");
+        $fresh = null;
+    }
+
+    // Phase 2 — command traffic across real Sentinel-driven failovers on the
+    // long-lived connection (retry-triggered client refreshes included).
+    for ($cycle = 1; $cycle <= 2; $cycle++) {
+        $oldAddress = $this->sentinelMasterAddress();
+
+        $this->toxiproxy->disable($this->proxyNameForPort($oldAddress['port']));
+
+        $newAddress = $this->waitForMasterChange($oldAddress);
+        $this->waitForProxyReady($newAddress['port'], 10);
+
+        expect($this->reissueUntilSuccess(
+            fn () => $connection->setex("soak:failover:{$cycle}", 120, "cycle-{$cycle}"),
+            attempts: 20
+        ))->toBeTrue();
+
+        // Re-open the cut node so Sentinel can demote it and the next cycle has a candidate
+        $this->toxiproxy->enable($this->proxyNameForPort($oldAddress['port']));
+        $this->waitForProxyReady($oldAddress['port'], 10);
+    }
+
+    gc_collect_cycles();
+
+    $memoryGrowth = memory_get_usage() - $memoryBaseline;
+    $fdGrowth = $fdCount() - $fdBaseline;
+
+    // Thresholds are deliberately generous: the point is catching unbounded
+    // growth (references held on replaced clients, context or cache
+    // accumulation), not measuring per-operation overhead.
+    expect($memoryGrowth)->toBeLessThanOrEqual(4 * 1024 * 1024)
+        ->and($fdGrowth)->toBeLessThanOrEqual(15);
+})->group('soak');


### PR DESCRIPTION
## Summary
- Add a soak test (group `soak`) asserting bounded memory and file-descriptor growth across 300 uncached `resolve()` calls and 2 forced Sentinel failovers on a long-lived connection
- Thresholds (4 MB / 15 FDs) deliberately generous: the goal is catching unbounded growth from references held on replaced clients, not measuring per-operation overhead
- Skips unless `SOAK=1`; runs via the new `composer test:soak` script and inside the `tests-chaos` CI job (which now sets `SOAK=1`)
- Documented in README (Resilience Testing) and AGENTS.md

Closes #106

## Test plan
- [x] Sensitivity check: thresholds lowered to an impossible value -> test fails on the assertion
- [x] Real thresholds: 300 churns + 2 failovers in ~17 s, ~1 MB memory growth, passes
- [x] Skips in 0.5 s without `SOAK=1`
- [x] `composer lint` and `composer stan` clean