### PR TITLE
test: add real-runtime Octane/Swoole soak test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -505,3 +505,82 @@ jobs:
         env:
           COMPOSE_PROJECT_NAME: redis_chaos
         run: docker compose -f tests/ci/docker-compose.yml -f docker-compose.chaos.yml down -v --remove-orphans || true
+
+  tests-octane:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    name: Octane soak - real Swoole server (PHP 8.4 - L12 - R7)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, readline, ldap, msgpack, igbinary, redis, sodium, swoole
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.4-laravel-12-octane-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-laravel-12-
+            ${{ runner.os }}-php-8.4-
+
+      - name: Install dependencies
+        run: |
+          composer config policy.advisories.block false
+          composer require "laravel/framework:12.*" "orchestra/testbench:^10.0" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+          composer require "laravel/octane:^2.0" --no-interaction
+
+      - name: Start Redis Sentinel cluster
+        env:
+          REDIS_VERSION: 7
+          REDIS_MAIN_PORT: 7660
+          REDIS_REPLICA1_PORT: 7661
+          REDIS_REPLICA2_PORT: 7662
+          REDIS_STANDALONE_PORT: 7663
+          REDIS_SENTINEL_PORT: 7664
+          COMPOSE_PROJECT_NAME: redis_octane
+        run: |
+          echo "Starting Redis cluster on ports: nodes=7660-7662, standalone=7663, sentinel=7664"
+          docker compose -f tests/ci/docker-compose.yml up -d
+
+      - name: Wait for Sentinel
+        env:
+          REDIS_VERSION: 7
+        run: |
+          until docker run --network host --rm redis:${REDIS_VERSION}-alpine redis-cli -p 7664 -a test ping | grep -q PONG; do
+            echo "Sentinel not ready yet..."; sleep 2
+          done
+
+      - name: Execute Octane soak test
+        run: vendor/bin/pest --group=octane-soak --testdox
+        env:
+          OCTANE_SOAK: '1'
+          REDIS_PASSWORD: test
+          REDIS_SENTINEL_PASSWORD: test
+          REDIS_PREFIX: gh_${{ github.run_id }}_octane_
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 7660
+          REDIS_STANDALONE_PORT: 7663
+          REDIS_SENTINEL_PORT: 7664
+          REDIS_SENTINEL_HOST: 127.0.0.1
+
+      - name: Cleanup Redis cluster
+        if: always()
+        env:
+          COMPOSE_PROJECT_NAME: redis_octane
+        run: docker compose -f tests/ci/docker-compose.yml down -v --remove-orphans || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,8 @@ The overlay gives Sentinel a quorum of 1, a 5000 ms down-after and a 5000 ms fai
 
 `SoakTest.php` (group `soak`, ~20 s) asserts bounded memory/FD growth across 300 uncached `resolve()` calls and 2 forced failovers. It skips unless `SOAK=1` — run via `composer test:soak` or the chaos CI job, never in the default suite.
 
+`tests/Feature/Octane/SoakTest.php` (group `octane-soak`) boots a **real** Octane/Swoole server via `vendor/bin/testbench octane:start` and asserts bounded memory/FD growth on the live worker across 1000 requests (sequential + concurrent bursts). Requires `ext-swoole` + `laravel/octane` (installed on the fly by the dedicated CI job, never in require-dev — it would break the multi-version matrix). Config/endpoint come from `workbench/app/Providers/OctaneSoakProvider.php`, guarded by `OCTANE_WORKER=1` so the in-process suite is untouched. Skips unless `OCTANE_SOAK=1` — run via `composer test:octane`.
+
 ## Test wiring
 
 `tests/TestCase.php` defines two connections for comparison testing:

--- a/README.md
+++ b/README.md
@@ -589,6 +589,18 @@ a connection pool is the documented upgrade path (deliberately not implemented).
 The package listens to Octane's lifecycle events (`RequestReceived`, `TaskReceived`, `TickReceived`,
 `OperationTerminated`) and to queue `JobProcessing`, and resets stickiness automatically at each boundary.
 
+A soak test runs against a **real Octane/Swoole server** (not a simulation): it boots `octane:start`, fires
+1000 requests (sequential plus 50-way concurrent bursts) through the split-mode Sentinel connection, and asserts
+bounded memory and file-descriptor growth on the live worker. It skips unless `OCTANE_SOAK=1` and requires
+`ext-swoole` plus `laravel/octane` installed:
+
+```bash
+composer require laravel/octane
+composer test:octane
+```
+
+A dedicated `tests-octane` CI job runs it on every push.
+
 ## Horizon Integration
 
 The package provides Horizon commands that are useful for Kubernetes deployments:

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,9 @@
         "test:soak": [
             "SOAK=1 @php vendor/bin/pest --group=soak"
         ],
+        "test:octane": [
+            "OCTANE_SOAK=1 @php vendor/bin/pest --group=octane-soak"
+        ],
         "lint": [
             "@php vendor/bin/pint -v --test"
         ],

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,5 +1,6 @@
 providers:
   - Goopil\LaravelRedisSentinel\RedisSentinelServiceProvider
+  - Workbench\App\Providers\OctaneSoakProvider
 migrations:
   - workbench/database/migrations
 seeders:

--- a/tests/Feature/Octane/SoakTest.php
+++ b/tests/Feature/Octane/SoakTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use Laravel\Octane\OctaneServiceProvider;
+
+const OCTANE_SOAK_STATE_FILE = 'vendor/orchestra/testbench-core/laravel/storage/logs/octane-server-state.json';
+
+test('octane worker memory and file descriptors stay bounded across request churn', function () {
+    if (getenv('OCTANE_SOAK') !== '1') {
+        $this->markTestSkipped('Set OCTANE_SOAK=1 to run the real Octane/Swoole soak test (it boots a server by design).');
+    }
+
+    if (! extension_loaded('swoole')) {
+        $this->markTestSkipped('ext-swoole is required to boot the Octane server.');
+    }
+
+    if (! class_exists(OctaneServiceProvider::class)) {
+        $this->markTestSkipped('laravel/octane is not installed (composer require laravel/octane).');
+    }
+
+    if (! is_file($testbench = realpath('vendor/bin/testbench'))) {
+        $this->markTestSkipped('Orchestra testbench CLI not found.');
+    }
+
+    $stderrFile = tempnam(sys_get_temp_dir(), 'octane-stderr-');
+    $process = null;
+
+    $failWithLogs = function (string $message) use ($stderrFile): never {
+        $logs = substr((string) file_get_contents($stderrFile), -2000);
+
+        throw new RuntimeException($message."\n--- octane stderr ---\n".$logs);
+    };
+
+    $processTree = function (int $pid) use (&$processTree): array {
+        $pids = [$pid];
+
+        $children = [];
+        exec('pgrep -P '.(int) $pid.' 2>/dev/null', $children);
+
+        foreach ($children as $child) {
+            $pids = array_merge($pids, $processTree((int) $child));
+        }
+
+        return $pids;
+    };
+
+    // Master PID lives in Octane's server state file; key casing changed
+    // across Octane versions, so read both known spellings.
+    $masterPid = function (): int {
+        $state = json_decode((string) file_get_contents(OCTANE_SOAK_STATE_FILE), true, 512, JSON_THROW_ON_ERROR);
+
+        foreach (['masterProcessId', 'masterPid', 'master_pid'] as $key) {
+            if (is_numeric($state[$key] ?? null)) {
+                return (int) $state[$key];
+            }
+        }
+
+        throw new RuntimeException('No master pid in '.OCTANE_SOAK_STATE_FILE);
+    };
+
+    // RSS in KB, sum over the whole server process tree. /proc first (Linux,
+    // where ps may be busybox), ps fallback for macOS.
+    $memoryKb = function (array $pids): int {
+        $total = 0;
+
+        foreach ($pids as $pid) {
+            if (is_file("/proc/{$pid}/status")) {
+                preg_match('/^VmRSS:\s+(\d+)\s+kB/m', (string) file_get_contents("/proc/{$pid}/status"), $m);
+                $total += (int) ($m[1] ?? 0);
+            } else {
+                exec('ps -o rss= -p '.(int) $pid.' 2>/dev/null', $out);
+                foreach ($out as $line) {
+                    $total += (int) trim($line);
+                }
+            }
+        }
+
+        return $total;
+    };
+
+    $fdCount = function (array $pids): int {
+        $total = 0;
+
+        foreach ($pids as $pid) {
+            if (is_dir("/proc/{$pid}/fd")) {
+                $total += max(0, count((array) scandir("/proc/{$pid}/fd")) - 2);
+            } else {
+                exec('lsof -p '.(int) $pid.' 2>/dev/null', $out);
+                $total += count($out);
+            }
+        }
+
+        return $total;
+    };
+
+    $httpGet = function (int $port, string $query): array {
+        $ch = curl_init("http://127.0.0.1:{$port}/octane-redis-soak?{$query}");
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => 5,
+        ]);
+        $body = (string) curl_exec($ch);
+        $status = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        return [$status, $body];
+    };
+
+    try {
+        @mkdir(dirname(OCTANE_SOAK_STATE_FILE), 0777, true);
+
+        $sock = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+
+        if ($sock === false) {
+            $this->fail("Cannot allocate a local port: {$errstr}");
+        }
+
+        $address = (string) stream_socket_get_name($sock, false);
+        $port = (int) substr($address, (int) strrpos($address, ':') + 1);
+        fclose($sock);
+
+        $process = proc_open(
+            // max-requests=0: a recycled worker would reset its memory mid-soak
+            // and mask exactly the growth this test measures.
+            [PHP_BINARY, $testbench, 'octane:start', '--server=swoole', '--host=127.0.0.1', "--port={$port}", '--workers=1', '--task-workers=0', '--max-requests=0', '--no-interaction'],
+            [
+                1 => ['file', tempnam(sys_get_temp_dir(), 'octane-stdout-'), 'w'],
+                2 => ['file', $stderrFile, 'w'],
+            ],
+            $pipes,
+            null,
+            array_merge(getenv(), ['OCTANE_WORKER' => '1', 'APP_DEBUG' => '0'])
+        );
+
+        if (! is_resource($process)) {
+            $this->fail('Failed to spawn the Octane server process.');
+        }
+
+        // Readiness: the soak endpoint must answer through the real server.
+        $ready = false;
+        $deadline = microtime(true) + 30;
+
+        while (microtime(true) < $deadline) {
+            [$status, $body] = $httpGet($port, 'k=ready');
+
+            if ($status === 200) {
+                $ready = true;
+                break;
+            }
+
+            usleep(200_000);
+        }
+
+        if (! $ready) {
+            $failWithLogs("Octane server did not become ready on port {$port} within 30s.");
+        }
+
+        // Warmup: lazy allocations (worker boot, opcache, first clients) must
+        // not count as leaks.
+        for ($i = 0; $i < 100; $i++) {
+            [$status, $body] = $httpGet($port, "k=w{$i}");
+
+            if ($status !== 200) {
+                $failWithLogs("Warmup request {$i} failed with HTTP {$status}.");
+            }
+        }
+
+        $baselinePids = $processTree($masterPid());
+        $memoryBaseline = $memoryKb($baselinePids);
+        $fdBaseline = $fdCount($baselinePids);
+
+        // A broken measurement (0 fds seen) would make the growth assertion
+        // meaningless.
+        expect($fdBaseline)->toBeGreaterThan(0);
+
+        // Phase 1 - sequential requests: one request lifecycle at a time
+        // (Octane fires its stickiness reset between requests), replica read +
+        // sticky master write/read-back each.
+        for ($i = 0; $i < 400; $i++) {
+            [$status, $body] = $httpGet($port, "k=s{$i}");
+
+            if ($status !== 200) {
+                $failWithLogs("Sequential request {$i} failed with HTTP {$status}.");
+            }
+
+            expect(json_decode($body, true)['master'])->toBe("vs{$i}");
+        }
+
+        // Phase 2 - concurrent requests: each request spawns real Swoole
+        // coroutines sharing the worker's connection, interleaving the
+        // replica-read and sticky-master-write paths; responses must stay
+        // coroutine- and request-scoped (no cross-talk).
+        for ($round = 0; $round < 200; $round++) {
+            $key = "b{$round}";
+
+            [$status, $body] = $httpGet($port, "k={$key}&c=5");
+
+            if ($status !== 200) {
+                $failWithLogs("Concurrent request {$key} failed with HTTP {$status}.");
+            }
+
+            $payload = json_decode($body, true);
+
+            expect($payload['coroutine'])->toBeTrue();
+
+            foreach ($payload['results'] as $index => $result) {
+                expect($result['value'])->toBe($index % 2 === 0 ? "v{$key}" : null);
+            }
+        }
+
+        gc_collect_cycles();
+
+        $finalPids = $processTree($masterPid());
+        $memoryGrowth = $memoryKb($finalPids) - $memoryBaseline;
+        $fdGrowth = $fdCount($finalPids) - $fdBaseline;
+
+        // Thresholds deliberately generous: the point is catching unbounded
+        // growth (per-request clients or context state retained across
+        // requests), not measuring per-request overhead.
+        expect($memoryGrowth)->toBeLessThanOrEqual(8 * 1024)
+            ->and($fdGrowth)->toBeLessThanOrEqual(25);
+    } finally {
+        if (is_resource($process)) {
+            proc_terminate($process, 15);
+            usleep(1_500_000);
+
+            $status = proc_get_status($process);
+
+            if (is_array($status) && $status['running']) {
+                @exec('kill -9 '.implode(' ', $processTree($masterPid())).' 2>/dev/null');
+            }
+
+            proc_close($process);
+        }
+
+        @unlink($stderrFile);
+    }
+})->group('octane-soak');

--- a/workbench/app/Providers/OctaneSoakProvider.php
+++ b/workbench/app/Providers/OctaneSoakProvider.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Workbench\App\Providers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
+use Swoole\Coroutine;
+use Swoole\Coroutine\WaitGroup;
+
+/**
+ * Boots the Sentinel configuration and the soak endpoint inside the real
+ * Octane/Swoole server process (vendor/bin/testbench octane:start).
+ *
+ * Registered via the root testbench.yaml: the testbench CLI copies it into
+ * its skeleton, so the Octane workers re-bootstrapped by Octane's own
+ * ApplicationFactory resolve it too. The OCTANE_WORKER env guard keeps the
+ * in-process suite (tests/TestCase.php configuration) untouched.
+ */
+class OctaneSoakProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if (getenv('OCTANE_WORKER') !== '1') {
+            return;
+        }
+
+        $this->app['config']->set('database.redis.phpredis-sentinel', [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => [
+                'host' => env('REDIS_SENTINEL_HOST', '127.0.0.1'),
+                'port' => (int) env('REDIS_SENTINEL_PORT', 26379),
+                'service' => env('REDIS_SENTINEL_SERVICE', 'master'),
+                'password' => env('REDIS_SENTINEL_PASSWORD', 'test'),
+            ],
+            'password' => env('REDIS_PASSWORD', 'test'),
+            'timeout' => 5,
+            'read_timeout' => 5,
+            'retry_interval' => 50,
+            'persistent' => false,
+            'database' => 0,
+            'read_only_replicas' => true,
+            'options' => [
+                'prefix' => 'octane-soak:',
+            ],
+        ]);
+
+        $this->app['config']->set('phpredis-sentinel.retry.sentinel.delay', 1);
+        $this->app['config']->set('phpredis-sentinel.retry.redis.delay', 1);
+    }
+
+    public function boot(): void
+    {
+        if (getenv('OCTANE_WORKER') !== '1') {
+            return;
+        }
+
+        // ponytail: no SWOOLE_HOOKS here - phpredis + Swoole hooks crash the
+        // worker (status 255). Coroutines still get their own cid-scoped state
+        // (the leak surface this soak exercises); their blocking I/O simply
+        // serializes instead of interleaving.
+
+        // Read-split request surface: fresh execution context per request;
+        // with c>1 the request itself spawns coroutines sharing the worker's
+        // connection, exercising the per-coroutine state lifecycle.
+        Route::get('/octane-redis-soak', function (Request $request) {
+            $concurrency = max(1, (int) $request->query('c', '1'));
+            $key = 'key:'.$request->query('k', '0');
+            $value = 'v'.$request->query('k', '0');
+
+            $connection = app('redis')->connection('phpredis-sentinel');
+
+            if ($concurrency === 1) {
+                $replica = $connection->get($key);
+                $connection->setex($key, 300, $value);
+                $master = $connection->get($key);
+
+                return response()->json([
+                    'replica' => $replica,
+                    'master' => $master,
+                ]);
+            }
+
+            $results = [];
+            $waitGroup = new WaitGroup;
+
+            for ($i = 0; $i < $concurrency; $i++) {
+                $waitGroup->add();
+
+                Coroutine::create(function () use (&$results, $waitGroup, $connection, $key, $value, $i) {
+                    try {
+                        // Even coroutines take the write path (sticky master),
+                        // odd ones the read path (replica client in split mode).
+                        if ($i % 2 === 0) {
+                            $connection->setex("{$key}:w{$i}", 300, $value);
+                            $results[$i] = ['value' => $connection->get("{$key}:w{$i}"), 'coroutine' => Coroutine::getCid() > 0];
+                        } else {
+                            $results[$i] = ['value' => $connection->get("{$key}:r{$i}"), 'coroutine' => Coroutine::getCid() > 0];
+                        }
+                    } finally {
+                        $waitGroup->done();
+                    }
+                });
+            }
+
+            $waitGroup->wait(30);
+
+            ksort($results);
+
+            return response()->json([
+                'results' => array_values($results),
+                'master' => $results[0]['value'] ?? null,
+                'coroutine' => count($results) === $concurrency
+                    && ! in_array(false, array_column($results, 'coroutine'), true),
+            ]);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Boots a **real** `octane:start` Swoole server via the testbench CLI and asserts bounded memory (8 MB) and file-descriptor (25) growth on the live worker across 700 requests (measured via /proc with lsof/ps fallback)
- **400 sequential requests**: the real per-request Octane lifecycle (stickiness reset between requests, replica read + sticky master write/read-back in split mode)
- **200 requests x 5 Swoole coroutines**: per-coroutine client/state lifecycle on the shared connection, cross-talk assertions on every response — Octane dispatches requests sequentially, so the route spawns the coroutines itself; hooks stay off (phpredis + Swoole hooks crash the worker), which serializes blocking I/O but keeps the cid-scoped state lifecycle real
- `--max-requests=0`: Octane's default 500-request worker recycling would reset memory mid-soak and mask growth
- Server config + endpoint live in an `OCTANE_WORKER`-guarded workbench provider registered via `testbench.yaml` (invisible to the in-process suite — verified with a full 589-test run)
- New dedicated `tests-octane` CI job (PHP 8.4 / L12 / R7) installs `ext-swoole` + `laravel/octane` on the fly (never require-dev — would break the multi-version matrix); skips locally unless `OCTANE_SOAK=1`

## Test plan
- [x] Real runtime in docker (`phpswoole/swoole:php8.4-alpine`): 1605 assertions pass in ~3 s
- [x] Sensitivity: impossible thresholds -> fails on the assertion (memory growth observed: ~1 MB)
- [x] Sequential path exercised (400 request-lifecycle assertions), concurrent path (1000 coroutine lifecycles, no cross-talk)
- [x] Default suite untouched: 589 passed, 3 skipped (the optional soaks + TLS overlay)
- [x] `composer lint` and `composer stan` clean