### PR TITLE
test: config-shape contract between connector, liveness and published schema

### DIFF
--- a/src/Commands/HorizonWorkerLiveness.php
+++ b/src/Commands/HorizonWorkerLiveness.php
@@ -71,10 +71,11 @@ class HorizonWorkerLiveness extends Command
     public function checkSentinel(RedisSentinelManager $manager): int
     {
         $connectionName = config('horizon.use');
-        // Same resolution order as RedisSentinelConnector::getService():
-        // nested sentinel.service first, then the connection-level key.
-        $service = config(sprintf('database.redis.%s.sentinel.service', $connectionName))
-            ?? config(sprintf('database.redis.%s.service', $connectionName));
+        // Same resolver as the connector: nested sentinel.service first, then
+        // the connection-level key (single source of truth, contract-tested).
+        $service = RedisSentinelConnector::serviceFromConfig(
+            (array) config(sprintf('database.redis.%s', $connectionName))
+        );
         $client = config(
             sprintf('database.redis.%s.client', $connectionName),
             config('database.redis.client')

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -122,7 +122,7 @@ class RedisSentinelConnector extends PhpRedisConnector
             throw new RedisException(sprintf('No sentinel config'));
         }
 
-        $service = $this->getService($config);
+        $service = static::serviceFromConfig($config);
 
         if (empty($service)) {
             throw new ConfigurationException(sprintf("No service name has been specified for the Redis Sentinel connection '%s'.", $name));
@@ -219,7 +219,7 @@ class RedisSentinelConnector extends PhpRedisConnector
      */
     protected function getMasterAddress(array $config, bool $refresh = false): array
     {
-        $service = $this->getService($config);
+        $service = static::serviceFromConfig($config);
 
         if ($refresh) {
             $this->masterCache->forgetMaster($this->getNodeCacheKey($config));
@@ -271,7 +271,7 @@ class RedisSentinelConnector extends PhpRedisConnector
      */
     protected function getReplicaAddress(array $config, bool $refresh = false): array
     {
-        $service = $this->getService($config);
+        $service = static::serviceFromConfig($config);
 
         if ($refresh) {
             $this->masterCache->forgetReplicas($this->getNodeCacheKey($config));
@@ -487,7 +487,7 @@ class RedisSentinelConnector extends PhpRedisConnector
      */
     public function getNodeCacheKey(array $config): string
     {
-        $service = $this->getService($config) ?? '';
+        $service = static::serviceFromConfig($config) ?? '';
 
         $endpoints = [];
 
@@ -510,7 +510,15 @@ class RedisSentinelConnector extends PhpRedisConnector
     /**
      * @param  array<string, mixed>  $config
      */
-    protected function getService(array $config): ?string
+    /**
+     * Single source of truth for the monitored master name. Nested
+     * `sentinel.service` wins over the connection-level `service` key; both
+     * readers in this package (connector, liveness probe) must route through
+     * this resolver so the schema contract cannot drift again (see 1.9.0).
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public static function serviceFromConfig(array $config): ?string
     {
         return $config['sentinel']['service'] ?? $config['service'] ?? null;
     }

--- a/tests/Unit/ConfigContractTest.php
+++ b/tests/Unit/ConfigContractTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Commands\HorizonWorkerLiveness;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
+use Illuminate\Support\Arr;
+
+/**
+ * Both 1.9.0 fixes shipped because two readers of the same configuration
+ * disagreed on its shape (service key location, uninitialized connections).
+ * These tests pin the schema contract: every reader must resolve documented
+ * keys identically, and the documented precedence must hold.
+ */
+test('service name resolves identically across every documented config shape', function (array $config, ?string $expected) {
+    expect(RedisSentinelConnector::serviceFromConfig($config))->toBe($expected);
+})->with([
+    'nested sentinel.service' => [['sentinel' => ['service' => 'nested']], 'nested'],
+    'connection-level service' => [['service' => 'level'], 'level'],
+    'both set: nested wins (documented precedence)' => [
+        ['sentinel' => ['service' => 'nested'], 'service' => 'level'],
+        'nested',
+    ],
+    'neither set: null' => [['sentinel' => ['host' => '127.0.0.1']], null],
+]);
+
+test('createSentinel refuses a connection without a service name before any sentinel call', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'sentinel' => ['host' => '127.0.0.1', 'port' => 26379],
+        ],
+    ]);
+
+    $connector = app(RedisSentinelConnector::class);
+
+    // The bug-2 repro: getMasterAddrByName(null) must never be reachable.
+    expect(fn () => $connector->createSentinel('phpredis-sentinel'))
+        ->toThrow(ConfigurationException::class);
+});
+
+test('liveness resolves the same service name as the connector for every config shape', function (array $config, string $expectedService) {
+    config([
+        'horizon.use' => 'phpredis-sentinel',
+        'database.redis.phpredis-sentinel' => $config,
+    ]);
+
+    $sentinel = Mockery::mock(RedisSentinel::class);
+    $sentinel->expects('getMasterAddrByName')
+        ->with($expectedService)
+        ->andReturns(['ip' => '127.0.0.1', 'port' => 26379]);
+
+    $connector = Mockery::mock(RedisSentinelConnector::class);
+    $connector->expects('createSentinel')->andReturns($sentinel);
+
+    $manager = Mockery::mock(RedisSentinelManager::class);
+    $manager->allows('resolveConnector')->andReturns($connector);
+
+    $command = new HorizonWorkerLiveness;
+    $command->setLaravel(app());
+
+    expect($command->checkSentinel($manager))->toBe(0);
+})->with([
+    'nested sentinel.service' => [
+        ['sentinel' => ['service' => 'nested', 'host' => '127.0.0.1']],
+        'nested',
+    ],
+    'connection-level service' => [
+        ['service' => 'level', 'sentinel' => ['host' => '127.0.0.1']],
+        'level',
+    ],
+    'both set: nested wins' => [
+        ['sentinel' => ['service' => 'nested', 'host' => '127.0.0.1'], 'service' => 'level'],
+        'nested',
+    ],
+]);
+
+test('liveness exits 1 without a service name instead of querying a null service', function () {
+    config([
+        'horizon.use' => 'phpredis-sentinel',
+        'database.redis.phpredis-sentinel' => [
+            'sentinel' => ['host' => '127.0.0.1', 'port' => 26379],
+        ],
+    ]);
+
+    $manager = Mockery::mock(RedisSentinelManager::class);
+    $manager->allows('resolveConnector')->andReturns(app(RedisSentinelConnector::class));
+
+    $command = new HorizonWorkerLiveness;
+    $command->setLaravel(app());
+
+    expect($command->checkSentinel($manager))->toBe(1);
+});
+
+test('the published config documents every global key the package reads', function () {
+    foreach ([
+        'override_laravel_redis',
+        'node_cache.ttl',
+        'read_commands',
+        'log.channel',
+        'log.notify_swallowed',
+        'commands.events.emit_success',
+        'retry.sentinel.attempts',
+        'retry.sentinel.delay',
+        'retry.sentinel.messages',
+        'retry.redis.attempts',
+        'retry.redis.delay',
+        'retry.redis.messages',
+    ] as $key) {
+        expect(Arr::has(config('phpredis-sentinel'), $key))->toBeTrue(
+            "phpredis-sentinel.{$key} is read by the package but missing from the published config."
+        );
+    }
+});


### PR DESCRIPTION
## Summary
- **Root-cause hardening for the 1.9.0 bug class**: both 1.9.0 fixes shipped because two readers of the same configuration disagreed on its shape (`horizon:alive` read the nested `sentinel.service` only; `connections()` crashed on uninitialized fresh instances)
- `RedisSentinelConnector::serviceFromConfig()`: single public resolver for the monitored master name (nested `sentinel.service` wins over connection-level `service`); `HorizonWorkerLiveness` now delegates to it instead of duplicating the precedence
- Contract tests:
  - service matrix: nested / connection-level / both (nested wins, documented precedence) / neither (null)
  - neither: `createSentinel` throws `ConfigurationException` **before any sentinel call** — `getMasterAddrByName(null)` stays unreachable (the bug-2 repro)
  - liveness parity: `checkSentinel` resolves the same service name as the connector for every documented shape
  - the published `phpredis-sentinel.php` documents every global key the package reads (`Arr::has` presence check, so a future rename cannot silently orphan a reader)

## Test plan
- [x] 10 new contract tests pass; existing Horizon liveness regression tests (argument-checked mocks) pass untouched — the static resolver bypasses the connector mock by design
- [x] Full unit suite: 172 passed
- [x] `composer lint` + `composer stan` clean