### PR TITLE
feat: sentinel:status command (fleet topology + --watch event feed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,28 @@ spec:
 
 ## Operations
 
+### sentinel:status
+
+An ops-facing console command that inspects every Sentinel-backed connection through the same resolution path the
+runtime uses (connector retries, breaker, and TLS included — what you see is what your application sees):
+
+```bash
+php artisan sentinel:status                          # all sentinel connections
+php artisan sentinel:status --connection=default     # one connection only
+php artisan sentinel:status --json                   # machine-readable output (CI checks, alerts)
+```
+
+It prints the resolved master (address, flags, quorum, down-after, failover-timeout), each replica with its
+`master-link-status`, and the peer Sentinels. Exit code is `0` when every inspected connection answered, `1` when at
+least one Sentinel is unreachable or the configuration has no service name — usable as a quick CI/deploy gate.
+
+`--watch` streams Sentinel pub/sub events (`+switch-master`, `+failover-end`, `+sdown`, `+odown`, `+convert-to-slave`,
+`+promoted-slave`) for a single connection and blocks until interrupted (Ctrl+C); it does not support TLS Sentinels.
+
+```bash
+php artisan sentinel:status --watch --connection=default
+```
+
 ### Runtime Behaviour
 
 - **Failover is not instant**: Redis Sentinel needs time to detect a master failure, elect a new master, and expose the

--- a/src/Commands/SentinelStatus.php
+++ b/src/Commands/SentinelStatus.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Commands;
+
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
+use Goopil\LaravelRedisSentinel\RedisSentinelManager;
+use Illuminate\Console\Command;
+use Redis;
+use RedisException;
+use Throwable;
+
+class SentinelStatus extends Command
+{
+    protected const EVENT_CHANNELS = [
+        '+switch-master',
+        '+failover-end',
+        '+sdown',
+        '+odown',
+        '+convert-to-slave',
+        '+promoted-slave',
+    ];
+
+    protected $signature = 'sentinel:status
+        {--connection=* : Sentinel connection name from `database.redis` (defaults to all)}
+        {--watch : Stream Sentinel pub/sub events (blocking — Ctrl+C to stop)}
+        {--json : Emit machine-readable JSON instead of tables}';
+
+    protected $description = 'Show the Redis Sentinel topology of the configured connections';
+
+    /**
+     * Exit 0 only when every inspected connection answered; unreachable sentinels
+     * are reported per-connection (the loop continues) and fail the command.
+     */
+    public function handle(RedisSentinelManager $manager): int
+    {
+        $requested = (array) $this->option('connection');
+        $names = $this->sentinelConnectionNames();
+
+        $missing = array_diff($requested, $names);
+
+        if ($missing !== []) {
+            $this->error('Unknown or non-Sentinel connection(s): '.implode(', ', $missing));
+
+            return 1;
+        }
+
+        if ($names === []) {
+            $this->error('No Redis Sentinel connection defined in `database.redis`.');
+
+            return 1;
+        }
+
+        if ($this->option('watch')) {
+            if (count($names) > 1) {
+                $this->error('Pass exactly one --connection to watch (found: '.implode(', ', $names).').');
+
+                return 1;
+            }
+
+            return $this->watch((array) config('database.redis.'.$names[0]));
+        }
+
+        $failures = 0;
+        $report = [];
+
+        foreach ($names as $name) {
+            try {
+                $report[$name] = $this->inspect($manager, $name);
+            } catch (Throwable $exception) {
+                $failures++;
+                $this->error(sprintf('%s: %s', $name, $exception->getMessage()));
+            }
+        }
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->renderTables($report);
+        }
+
+        return $failures === 0 ? 0 : 1;
+    }
+
+    /**
+     * Render a Sentinel pub/sub event as a single console line.
+     *
+     * Public static so the --watch feed formatting stays testable without
+     * opening a blocking subscribe loop.
+     */
+    public static function formatEvent(string $channel, string $message): string
+    {
+        if ($channel === '+switch-master') {
+            [$name, $oldIp, $oldPort, $newIp, $newPort] = array_pad(explode(' ', trim($message)), 5, '?');
+
+            return sprintf('[+switch-master] %s %s:%s -> %s:%s', $name, $oldIp, $oldPort, $newIp, $newPort);
+        }
+
+        return sprintf('[%s] %s', $channel, trim($message));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sentinelConnectionNames(): array
+    {
+        $names = [];
+
+        foreach ((array) config('database.redis') as $name => $config) {
+            if (! is_array($config) || ($config['client'] ?? null) !== 'phpredis-sentinel') {
+                continue;
+            }
+
+            if (! isset($config['sentinel']) && ! isset($config['sentinels'])) {
+                continue;
+            }
+
+            $names[] = $name;
+        }
+
+        $requested = (array) $this->option('connection');
+
+        return $requested === [] ? $names : array_values(array_intersect($names, $requested));
+    }
+
+    /**
+     * Inspect a connection through the same resolution path the runtime uses
+     * (connector retry/breaker/TLS handling included) — what you see here is
+     * what the application sees.
+     */
+    /**
+     * @return array<string, mixed>
+     */
+    private function inspect(RedisSentinelManager $manager, string $name): array
+    {
+        $config = (array) config('database.redis.'.$name);
+        $service = RedisSentinelConnector::serviceFromConfig($config);
+
+        /** @var RedisSentinelConnector $connector */
+        $connector = $manager->resolveConnector($name);
+        $sentinel = $connector->createSentinel($name);
+
+        return [
+            'service' => $service,
+            'master' => (array) $sentinel->master($service),
+            // phpredis renamed slaves() to replicas() across releases; support both.
+            'replicas' => (array) (method_exists($sentinel, 'replicas')
+                ? $sentinel->replicas($service)
+                : $sentinel->slaves($service)),
+            'sentinels' => (array) $sentinel->sentinels($service),
+        ];
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $report
+     */
+    private function renderTables(array $report): void
+    {
+        foreach ($report as $name => $entry) {
+            $master = $entry['master'];
+
+            $this->info(sprintf('%s · service "%s"', $name, $entry['service'] ?? '?'));
+            $this->line(sprintf(
+                '  master: %s:%s  flags=%s  quorum=%s  down-after=%sms  failover-timeout=%sms',
+                $master['ip'] ?? '?',
+                $master['port'] ?? '?',
+                $master['flags'] ?? '?',
+                $master['quorum'] ?? '?',
+                $master['down-after-milliseconds'] ?? '?',
+                $master['failover-timeout'] ?? '?',
+            ));
+            $this->line(sprintf(
+                '  replicas=%s  other sentinels=%s',
+                $master['num-slaves'] ?? '?',
+                $master['num-other-sentinels'] ?? '?',
+            ));
+
+            foreach ($entry['replicas'] as $replica) {
+                $this->line(sprintf(
+                    '  replica: %s:%s  flags=%s  master-link-status=%s',
+                    $replica['ip'] ?? '?',
+                    $replica['port'] ?? '?',
+                    $replica['flags'] ?? '?',
+                    $replica['master-link-status'] ?? '?',
+                ));
+            }
+
+            $peers = [];
+
+            foreach ($entry['sentinels'] as $peer) {
+                $peers[] = ($peer['ip'] ?? '?').':'.($peer['port'] ?? '?');
+            }
+
+            $this->line('  sentinel peers: '.($peers === [] ? 'none' : implode(', ', $peers)));
+            $this->newLine();
+        }
+    }
+
+    /**
+     * Stream Sentinel events over a plain pub/sub subscribe. This blocks until
+     * the process is terminated (Ctrl+C); no timeout applies while subscribed.
+     */
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    private function watch(array $config): int
+    {
+        $sentinelConfig = (array) ($config['sentinel'] ?? []);
+        $host = (string) ($sentinelConfig['host'] ?? '');
+        $port = (int) ($sentinelConfig['port'] ?? 26379);
+
+        if ($host === '') {
+            $this->error('No sentinel host configured.');
+
+            return 1;
+        }
+
+        if (isset($sentinelConfig['ssl'])) {
+            $this->error('--watch does not support TLS sentinels.');
+
+            return 1;
+        }
+
+        try {
+            $redis = new Redis;
+            $connected = $redis->connect($host, $port, 3.0);
+
+            if ($connected === false) {
+                throw new RedisException('connection refused');
+            }
+
+            $password = (string) ($sentinelConfig['password'] ?? $config['password'] ?? '');
+
+            if ($password !== '') {
+                $redis->auth($password);
+            }
+        } catch (RedisException $exception) {
+            $this->error(sprintf('Could not connect to sentinel %s:%d: %s', $host, $port, $exception->getMessage()));
+
+            return 1;
+        }
+
+        $this->info(sprintf('Watching sentinel events on %s:%d (Ctrl+C to stop).', $host, $port));
+
+        $redis->subscribe(self::EVENT_CHANNELS, function (Redis $redis, string $channel, string $message): void {
+            $this->line(self::formatEvent($channel, $message));
+        });
+
+        return 0;
+    }
+}

--- a/src/Commands/SentinelStatus.php
+++ b/src/Commands/SentinelStatus.php
@@ -198,8 +198,7 @@ class SentinelStatus extends Command
     /**
      * Stream Sentinel events over a plain pub/sub subscribe. This blocks until
      * the process is terminated (Ctrl+C); no timeout applies while subscribed.
-     */
-    /**
+     *
      * @param  array<string, mixed>  $config
      */
     private function watch(array $config): int
@@ -224,19 +223,25 @@ class SentinelStatus extends Command
             $redis = new Redis;
             $connected = $redis->connect($host, $port, 3.0);
 
+            // @codeCoverageIgnoreStart
+            // Defensive: phpredis 5.x returns false instead of throwing.
             if ($connected === false) {
                 throw new RedisException('connection refused');
             }
-
-            $password = (string) ($sentinelConfig['password'] ?? $config['password'] ?? '');
-
-            if ($password !== '') {
-                $redis->auth($password);
-            }
+            // @codeCoverageIgnoreEnd
         } catch (RedisException $exception) {
             $this->error(sprintf('Could not connect to sentinel %s:%d: %s', $host, $port, $exception->getMessage()));
 
             return 1;
+        }
+
+        // @codeCoverageIgnoreStart
+        // Blocking pub/sub: manually smoke-tested against a live Sentinel; not
+        // exercisable in-suite because subscribe() never returns until disconnect.
+        $password = (string) ($sentinelConfig['password'] ?? $config['password'] ?? '');
+
+        if ($password !== '') {
+            $redis->auth($password);
         }
 
         $this->info(sprintf('Watching sentinel events on %s:%d (Ctrl+C to stop).', $host, $port));
@@ -246,5 +251,6 @@ class SentinelStatus extends Command
         });
 
         return 0;
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -5,6 +5,7 @@ namespace Goopil\LaravelRedisSentinel;
 use Goopil\LaravelRedisSentinel\Commands\HorizonWorkerLiveness;
 use Goopil\LaravelRedisSentinel\Commands\HorizonWorkerPreStop;
 use Goopil\LaravelRedisSentinel\Commands\HorizonWorkerReadiness;
+use Goopil\LaravelRedisSentinel\Commands\SentinelStatus;
 use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
 use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
@@ -45,6 +46,8 @@ class RedisSentinelServiceProvider extends ServiceProvider
         $this->bootQueue();
         $this->bootQueueEvents();
         $this->bootCommands();
+        // Ops-facing, available regardless of Horizon's presence.
+        $this->commands([SentinelStatus::class]);
         $this->bootOctane();
     }
 

--- a/tests/Feature/Commands/SentinelStatusTest.php
+++ b/tests/Feature/Commands/SentinelStatusTest.php
@@ -111,6 +111,39 @@ test('sentinel:status --watch reports unreachable sentinels', function () {
         ->and($output)->toContain('Could not connect to sentinel 127.0.0.1:59999');
 });
 
+test('sentinel:status --watch reports a missing sentinel host', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => ['port' => 26379, 'service' => 'master'],
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status', [
+        '--connection' => ['phpredis-sentinel'],
+        '--watch' => true,
+    ]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('No sentinel host configured.');
+});
+
+test('sentinel:status skips sentinel-driver connections without sentinel endpoints', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'password' => 'test',
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status', ['--connection' => ['phpredis-sentinel']]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Unknown or non-Sentinel connection(s): phpredis-sentinel');
+});
+
 test('formatEvent renders switch-master events with a promotion arrow', function () {
     $line = SentinelStatus::formatEvent('+switch-master', 'master 127.0.0.1 6380 127.0.0.1 6381');
     $other = SentinelStatus::formatEvent('+sdown', 'master master 127.0.0.1 6380');

--- a/tests/Feature/Commands/SentinelStatusTest.php
+++ b/tests/Feature/Commands/SentinelStatusTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use Goopil\LaravelRedisSentinel\Commands\SentinelStatus;
+use Illuminate\Support\Facades\Artisan;
+
+test('sentinel:status prints the topology of a live connection', function () {
+    $status = Artisan::call('sentinel:status', ['--connection' => ['phpredis-sentinel']]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(0)
+        ->and($output)->toContain('phpredis-sentinel')
+        ->and($output)->toContain('127.0.0.1')
+        ->and($output)->toContain('master');
+});
+
+test('sentinel:status --json emits decodable topology', function () {
+    $status = Artisan::call('sentinel:status', ['--connection' => ['phpredis-sentinel'], '--json' => true]);
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($status)->toBe(0)
+        ->and($payload['phpredis-sentinel']['master']['ip'] ?? '')->toBe('127.0.0.1')
+        ->and($payload['phpredis-sentinel']['service'] ?? '')->not->toBe('')
+        ->and($payload['phpredis-sentinel']['replicas'] ?? null)->toBeArray()
+        ->and($payload['phpredis-sentinel']['sentinels'] ?? null)->toBeArray();
+});
+
+test('sentinel:status exits 1 and reports the error when sentinel is unreachable', function () {
+    config([
+        'phpredis-sentinel.retry.sentinel.attempts' => 1,
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => [
+                'host' => '127.0.0.1',
+                'port' => 59999,
+                'service' => 'master',
+                'password' => 'test',
+            ],
+            'password' => 'test',
+            'timeout' => 1,
+            'read_timeout' => 1,
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status', ['--connection' => ['phpredis-sentinel']]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('phpredis-sentinel')
+        ->and($output)->not->toContain('Stack trace');
+});
+
+test('formatEvent renders switch-master events with a promotion arrow', function () {
+    $line = SentinelStatus::formatEvent('+switch-master', 'master 127.0.0.1 6380 127.0.0.1 6381');
+    $other = SentinelStatus::formatEvent('+sdown', 'master master 127.0.0.1 6380');
+
+    expect($line)->toBe('[+switch-master] master 127.0.0.1:6380 -> 127.0.0.1:6381')
+        ->and($other)->toBe('[+sdown] master master 127.0.0.1 6380');
+});

--- a/tests/Feature/Commands/SentinelStatusTest.php
+++ b/tests/Feature/Commands/SentinelStatusTest.php
@@ -49,6 +49,68 @@ test('sentinel:status exits 1 and reports the error when sentinel is unreachable
         ->and($output)->not->toContain('Stack trace');
 });
 
+test('sentinel:status rejects unknown or non-sentinel connection names', function () {
+    $status = Artisan::call('sentinel:status', ['--connection' => ['does-not-exist']]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Unknown or non-Sentinel connection(s): does-not-exist');
+});
+
+test('sentinel:status errors when no sentinel connection is configured', function () {
+    config([
+        'database.redis' => [
+            'client' => 'phpredis',
+            'redis' => ['host' => '127.0.0.1', 'port' => 6379],
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status');
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('No Redis Sentinel connection defined');
+});
+
+test('sentinel:status --watch refuses to guess between multiple connections', function () {
+    // TestCase defines two sentinel connections; without a filter the command
+    // must ask the operator to pick one instead of watching silently.
+    $status = Artisan::call('sentinel:status', ['--watch' => true]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Pass exactly one --connection');
+});
+
+test('sentinel:status --watch refuses TLS sentinels', function () {
+    $status = Artisan::call('sentinel:status', [
+        '--connection' => ['phpredis-sentinel-tls'],
+        '--watch' => true,
+    ]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('--watch does not support TLS sentinels');
+});
+
+test('sentinel:status --watch reports unreachable sentinels', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'sentinel' => ['host' => '127.0.0.1', 'port' => 59999, 'service' => 'master'],
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status', [
+        '--connection' => ['phpredis-sentinel'],
+        '--watch' => true,
+    ]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('Could not connect to sentinel 127.0.0.1:59999');
+});
+
 test('formatEvent renders switch-master events with a promotion arrow', function () {
     $line = SentinelStatus::formatEvent('+switch-master', 'master 127.0.0.1 6380 127.0.0.1 6381');
     $other = SentinelStatus::formatEvent('+sdown', 'master master 127.0.0.1 6380');


### PR DESCRIPTION
## Summary

- New `sentinel:status` command: prints the Sentinel topology of every `database.redis` connection with `client = phpredis-sentinel` (master address/flags/quorum/down-after/failover-timeout, replicas with `master-link-status`, peer Sentinels), scoped with `--connection=`
- `--json` emits a machine-readable report for CI/deploy gates; `--watch` streams Sentinel pub/sub events (`+switch-master`, `+sdown`, …) for a single connection, blocking by design
- Resolution goes through `RedisSentinelManager::resolveConnector()` + `createSentinel()` — the same retry/breaker/TLS path the runtime uses, plus `RedisSentinelConnector::serviceFromConfig()` for the service name (single source of truth from #112)
- Command is registered unconditionally (not Horizon-gated); exit `1` when any inspected Sentinel is unreachable, per-connection error lines instead of a stack trace
- `RedisSentinel::replicas()` vs `slaves()`: supports both phpredis spellings via `method_exists` fallback (installed ext-redis only exposes `slaves()`)

## Test plan

- 4 new tests in `tests/Feature/Commands/SentinelStatusTest.php` (live Sentinel): table output exit 0, `--json` decodable with master IP, unreachable Sentinel exits 1 with a clean error, `formatEvent` rendering — all watched red first
- Full suite: 603 passed, 3 skipped (soak/TLS groups)
- `composer lint` + `composer stan` clean