### PR TITLE
fix: surface phpredis 6 silent EVAL errors to the retry layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,10 @@ php artisan sentinel:status --watch --connection=default
 
 - **Failover is not instant**: Redis Sentinel needs time to detect a master failure, elect a new master, and expose the
   new topology. During this window, commands may be retried and application latency can temporarily increase.
+- **The failover window is also a data-loss window**: replication is asynchronous, so a Sentinel failover promotes the
+  replica with the most complete — not necessarily complete — dataset. Anything written in the last replication lag
+  before the old master died is lost, and the old master rejoins as a replica and re-syncs. This is standard
+  Redis/Valkey Sentinel behavior, not something the driver can prevent; only `WAIT`-confirmed writes are safe from it.
 - **Resolved node addresses are cached during execution** (`node_cache.ttl`, default 15 s): the package avoids querying
   Sentinel for every command. When a connection error, read-only error, or failover-related error is detected, the
   connection is refreshed and Sentinel is queried again.

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -474,7 +474,28 @@ class RedisSentinelConnection extends PhpRedisConnection
                 $this->client = $targetClient;
 
                 try {
-                    return $callback();
+                    // phpredis >= 6 reports EVAL/EVALSHA server errors (e.g. -READONLY
+                    // from a node demoted by a failover) only through getLastError(),
+                    // returning false instead of throwing, so the retry below would
+                    // never see the failure and a queue push would be silently dropped.
+                    // A script legitimately returning nil also yields false, so the
+                    // stored error is the only discriminator; clear it first so a stale
+                    // error from a previous command cannot false-positive.
+                    if ($this->isScriptCommand($name)) {
+                        $targetClient->clearLastError();
+                    }
+
+                    $result = $callback();
+
+                    if ($result === false && $this->isScriptCommand($name)) {
+                        $error = $targetClient->getLastError();
+
+                        if ($error !== null) {
+                            throw new RedisException($error);
+                        }
+                    }
+
+                    return $result;
                 } finally {
                     $this->client = $previous;
                 }
@@ -636,5 +657,14 @@ class RedisSentinelConnection extends PhpRedisConnection
     protected function isReadOnlyCommand(string $method): bool
     {
         return in_array(strtolower($method), $this->readOnlyCommands ?? self::READ_ONLY_COMMAND);
+    }
+
+    /**
+     * phpredis >= 6 reports EVAL/EVALSHA server errors only through
+     * Redis::getLastError(), returning false instead of throwing.
+     */
+    private function isScriptCommand(string $method): bool
+    {
+        return in_array(strtolower($method), ['eval', 'evalsha'], true);
     }
 }

--- a/tests/Feature/Toxiproxy/FailoverTest.php
+++ b/tests/Feature/Toxiproxy/FailoverTest.php
@@ -3,6 +3,7 @@
 use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionReconnected;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
 
 describe('Real Sentinel failover through toxiproxy', function () {
@@ -95,6 +96,44 @@ describe('Real Sentinel failover through toxiproxy', function () {
             ->and($stale->get('chaos_readonly'))->toBe('v2');
 
         Event::assertDispatched(RedisSentinelConnectionReconnected::class);
+
+        $cached = app(NodeAddressCache::class)->get(sentinelNodeCacheKey());
+        expect($cached['port'])->toBe($newAddress['port'], 'Cache must be refreshed to the promoted master');
+    });
+
+    test('queue push on a connection still pointing at the demoted master retries through Sentinel instead of surfacing READONLY', function () {
+        config()->set('queue.connections.redis.connection', 'phpredis-sentinel');
+
+        $oldAddress = $this->sentinelMasterAddress();
+
+        // Recreate the roast R1 state: failover completes AND the old master is back
+        // online as a replica, so writes against it raise -READONLY (not a transport error)
+        $this->toxiproxy->disable($this->proxyNameForPort($oldAddress['port']));
+        $newAddress = $this->waitForMasterChange($oldAddress);
+        $this->toxiproxy->enable($this->proxyNameForPort($oldAddress['port']));
+        expect($this->waitForReplicaRole($this->nodePortForProxyPort($oldAddress['port']), 'slave', 30))
+            ->toBeTrue('Old master should be demoted to replica');
+
+        // Mimic a long-running queue worker whose resolved master address survived the
+        // failover, then force a fresh connection that reads the stale cache
+        app(NodeAddressCache::class)->set(sentinelNodeCacheKey(), $oldAddress['ip'], $oldAddress['port']);
+        $this->purgeSentinelConnection();
+
+        // The push's eval targets the demoted node: phpredis 6 reports the -READONLY
+        // script error only through getLastError() (no exception), so the retry must
+        // surface it, re-resolve the promoted master through Sentinel and replay the
+        // push instead of silently dropping the job
+        $payload = json_encode(['id' => 'chaos-queue-'.uniqid(), 'job' => 'chaos', 'data' => []]);
+        expect(Queue::connection('redis')->pushRaw($payload))->not->toBeNull();
+
+        $probe = new \Redis;
+        $probe->connect($newAddress['ip'], $newAddress['port']);
+        $probe->auth(getenv('REDIS_PASSWORD') ?: 'test');
+        $keys = $probe->keys('*queues*');
+        $probe->close();
+
+        expect($keys)->toBeArray()->not->toBeEmpty('Push must land the job on the promoted master')
+            ->and(Redis::connection('phpredis-sentinel')->lLen('queues:default'))->toBeGreaterThanOrEqual(1);
 
         $cached = app(NodeAddressCache::class)->get(sentinelNodeCacheKey());
         expect($cached['port'])->toBe($newAddress['port'], 'Cache must be refreshed to the promoted master');

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -4,6 +4,7 @@ use Goopil\LaravelRedisSentinel\Connections\RedisSentinelConnection;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionFailed;
 use Goopil\LaravelRedisSentinel\Events\RedisSentinelConnectionMaxRetryFailed;
 use Goopil\LaravelRedisSentinel\Tests\Support\FakeContext;
+use Goopil\LaravelRedisSentinel\Tests\Unit\Stubs\ScriptFakeRedis;
 use Illuminate\Support\Facades\Event;
 
 test('a failing dynamic command is retried exactly retryLimit + 1 times', function () {
@@ -215,4 +216,78 @@ test('a non-transport exception thrown inside transaction() is never replayed', 
 
     expect($calls)->toBe(1)
         ->and(Event::assertDispatchedTimes(RedisSentinelConnectionFailed::class, 0))->toBeNull();
+});
+
+test('a phpredis 6 silent eval error surfaces through getLastError and is retried via Sentinel', function () {
+    Event::fake();
+
+    // Mockery cannot override eval() (reserved word falls through to the real
+    // client), so the phpredis >= 6 silent-error contract is simulated by a stub
+    $readonlyError = "ERR Error running script (call to f_abc): @user_script:1: -READONLY You can't write against a read only replica.";
+
+    $demotedMaster = new ScriptFakeRedis;
+    $demotedMaster->nextError = $readonlyError;
+
+    $promotedMaster = new ScriptFakeRedis;
+
+    $refreshes = 0;
+    $connection = new RedisSentinelConnection(
+        $demotedMaster,
+        function () use (&$refreshes, $promotedMaster) {
+            $refreshes++;
+
+            return $promotedMaster;
+        },
+        [],
+    );
+    $connection->setRetryLimit(2);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(["can't write against a read only replica"]);
+
+    // Laravel's queue push script returns nil: a successful eval is also a false
+    // result, so only the stored error can tell failure from success
+    expect($connection->eval("redis.call('rpush', KEYS[1], ARGV[1])", 2, 'queues:default', 'queues:default:notify'))->toBeFalse()
+        ->and($refreshes)->toBe(1);
+});
+
+test('an eval returning false without a stored error is returned as-is with no retry', function () {
+    Event::fake();
+
+    $master = new ScriptFakeRedis;
+
+    $connection = new RedisSentinelConnection($master, fn () => throw new RuntimeException('must not refresh'), []);
+    $connection->setRetryLimit(2);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(["can't write against a read only replica"]);
+
+    expect($connection->eval('return nil', 0))->toBeFalse();
+});
+
+test('a phpredis 6 eval error that stays on the same node exhausts the retry budget and surfaces the stored error', function () {
+    Event::fake();
+
+    $readonlyError = "ERR Error running script: -READONLY You can't write against a read only replica.";
+
+    $demotedMaster = new ScriptFakeRedis;
+    $demotedMaster->nextError = $readonlyError;
+
+    $connection = new RedisSentinelConnection(
+        $demotedMaster,
+        function () use ($demotedMaster) {
+            // Sentinel still reports the demoted node: refresh hands back the same client
+            return $demotedMaster;
+        },
+        [],
+    );
+    $connection->setRetryLimit(2);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(["can't write against a read only replica"]);
+
+    try {
+        $connection->eval("redis.call('rpush', KEYS[1], ARGV[1])", 2, 'queues:default');
+        $this->fail('RedisException was not thrown.');
+    } catch (RedisException $exception) {
+        expect($exception->getMessage())->toContain('-READONLY')
+            ->and(Event::assertDispatchedTimes(RedisSentinelConnectionMaxRetryFailed::class, 1))->toBeNull();
+    }
 });

--- a/tests/Unit/Stubs/ScriptFakeRedis.php
+++ b/tests/Unit/Stubs/ScriptFakeRedis.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Goopil\LaravelRedisSentinel\Tests\Unit\Stubs;
+
+/**
+ * Simulates phpredis >= 6 EVAL semantics without a live server: server errors
+ * are NOT thrown, they are stored via getLastError() while eval() returns false
+ * (the same reply a successful script returning nil produces).
+ */
+class ScriptFakeRedis extends \Redis
+{
+    public ?string $nextError = null;
+
+    private ?string $lastError = null;
+
+    public function eval(string $script, array $args = [], int $num_keys = 0): mixed
+    {
+        if ($this->nextError !== null) {
+            $this->lastError = $this->nextError;
+        }
+
+        return false;
+    }
+
+    public function clearLastError(): bool
+    {
+        $this->lastError = null;
+
+        return true;
+    }
+
+    public function getLastError(): ?string
+    {
+        return $this->lastError;
+    }
+}


### PR DESCRIPTION
## Summary

- **phpredis >= 6 turns EVAL server errors into a silent `false` return** instead of throwing (verified on 6.3.0: syntax errors, runtime errors and `-READONLY` all come back as `false` + `getLastError()`). The driver's retry layer is exception-driven, so a queue push (`RedisQueue::pushRaw` is `eval`-based) evaluated on a node demoted by a failover raised no error and **the job was silently dropped** — no exception, no retry, no queue entry.
- The retry wrapper now checks `getLastError()` for `eval`/`evalsha` when the result is `false` and throws the stored error, so the existing bounded retry + Sentinel re-resolve handles it. A script legitimately returning `nil` (e.g. Laravel's queue push script) also yields `false` with **no** stored error and is returned untouched — zero false positives, zero extra round trips (`getLastError`/`clearLastError` are local state).
- README: document that the failover window is also a data-loss window (async replication, standard Sentinel behavior).

## Context

Found during the 2026-09-11 chaos roast: cache writes during a failover were held by the retry policy until the new master was promoted, but queue pushes dispatched in the same window never reached the queue. On phpredis 5 the eval error throws (and matches the retryable messages); on phpredis 6 the failure is invisible without this change.

## Test plan

- Unit (`tests/Unit/Stubs/ScriptFakeRedis`): silent eval error is retried via Sentinel and lands on the refreshed client; a nil-result eval is returned as-is with no retry; an error that persists exhausts the retry budget and surfaces the stored error.
- Chaos (`tests/Feature/Toxiproxy/FailoverTest.php`): queue push on a connection still pointing at the demoted master — job must land on the promoted master, `NodeAddressCache` must be refreshed (failed before the fix, passes after).
- Full suite: 617 passed, 3 skipped (soak), `composer lint` clean.