### PR TITLE
fix: roast follow-ups — stale replica filter, silent fcall errors, leak guard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -631,10 +631,18 @@ jobs:
       - name: Start Redis cluster with TLS overlay
         run: docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
 
-      - name: Wait for TLS Sentinel
+      - name: Wait for TLS Sentinel and master
         run: |
-          until openssl s_client -connect 127.0.0.1:26383 -CAfile tests/tls/ca.crt </dev/null 2>/dev/null | grep -q "Verify return code: 0"; do
-            echo "TLS Sentinel not ready yet..."; sleep 2
+          deadline=$((SECONDS+60))
+          for port in 26383 6393; do
+            until openssl s_client -connect 127.0.0.1:$port -CAfile tests/tls/ca.crt </dev/null 2>/dev/null | grep -q "Verify return code: 0"; do
+              if [ $SECONDS -gt $deadline ]; then
+                echo "TLS port $port never became ready, dumping container logs:"
+                docker compose -f docker-compose.yml -f docker-compose.tls.yml logs --tail=50 tls-main tls-sentinel
+                exit 1
+              fi
+              echo "TLS port $port not ready yet..."; sleep 2
+            done
           done
 
       - name: Execute TLS tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,8 +139,10 @@ jobs:
           LARAVEL_INDEX=${{ matrix.laravel }}  # 10, 11, 12
           REDIS_INDEX=${{ matrix.redis }}  # 6, 7
 
-          # Calculate unique index: ((PHP-2)*8 + (LARAVEL-10)*2 + (REDIS-6))
-          MATRIX_INDEX=$(( (PHP_INDEX - 2) * 8 + (LARAVEL_INDEX - 10) * 2 + (REDIS_INDEX - 6) ))
+          # Calculate unique index: ((PHP-2)*12 + (LARAVEL-10)*3 + (REDIS-6))
+          # LARAVEL spans 0..3 and REDIS 0..2, so the Laravel multiplier must be 3
+          # to keep (L,R) pairs collision-free
+          MATRIX_INDEX=$(( (PHP_INDEX - 2) * 12 + (LARAVEL_INDEX - 10) * 3 + (REDIS_INDEX - 6) ))
           PORT_BASE=$((7000 + MATRIX_INDEX * 10))
 
           echo "Matrix combination: PHP ${{ matrix.php }}, Laravel ${{ matrix.laravel }}, Redis ${{ matrix.redis }}"
@@ -584,3 +586,66 @@ jobs:
         env:
           COMPOSE_PROJECT_NAME: redis_octane
         run: docker compose -f tests/ci/docker-compose.yml down -v --remove-orphans || true
+
+  tests-tls:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    name: TLS - Sentinel + data connections over TLS (PHP 8.4 - L12)
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, readline, ldap, msgpack, igbinary, redis, sodium
+          tools: composer:v2
+          coverage: none
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.4-laravel-12-tls-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-laravel-12-
+            ${{ runner.os }}-php-8.4-
+
+      - name: Install dependencies
+        run: |
+          composer config policy.advisories.block false
+          composer require "laravel/framework:12.*" "orchestra/testbench:^10.0" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Generate TLS certificates
+        run: ./tests/tls/generate-certs.sh
+
+      - name: Start Redis cluster with TLS overlay
+        run: docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+
+      - name: Wait for TLS Sentinel
+        run: |
+          until openssl s_client -connect 127.0.0.1:26383 -CAfile tests/tls/ca.crt </dev/null 2>/dev/null | grep -q "Verify return code: 0"; do
+            echo "TLS Sentinel not ready yet..."; sleep 2
+          done
+
+      - name: Execute TLS tests
+        run: vendor/bin/pest tests/Feature/TlsConnectionTest.php --testdox
+        env:
+          REDIS_PASSWORD: test
+          REDIS_SENTINEL_PASSWORD: test
+          REDIS_PREFIX: gh_${{ github.run_id }}_tls_
+          REDIS_SENTINEL_TLS_HOST: 127.0.0.1
+          REDIS_SENTINEL_TLS_PORT: 26383
+
+      - name: Cleanup TLS cluster
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.tls.yml down -v --remove-orphans || true

--- a/README.md
+++ b/README.md
@@ -893,6 +893,11 @@ Events\RedisSentinelConnectionMaxRetryFailed::class
 Events\RedisSentinelReplicaFallback::class
 ```
 
+> Listeners for these events MUST be synchronous: the connection events carry the live
+> `RedisSentinelConnection` (and the thrown exception), which is not serializable. A
+> queued (`ShouldQueue`) listener crashes during event serialization and the failure is
+> only logged — the listener job never runs.
+
 ### Horizon Worker Events
 
 The Kubernetes probe commands also dispatch worker lifecycle events:

--- a/README.md
+++ b/README.md
@@ -634,8 +634,14 @@ than the retry budget never restarts the pod. See [Kubernetes Deployment](#kuber
 
 ### Horizon Configuration
 
+Horizon must run with this package as its driver: when `horizon.driver` is `phpredis-sentinel`, the manager wires
+Horizon's queue onto the Sentinel-aware connector (job events, prefix patching and probe integration). Without it,
+Horizon silently falls back to its base Redis connector and the integration does not apply:
+
 ```php
 // config/horizon.php
+'driver' => 'phpredis-sentinel', // Required: activates this package's Horizon integration
+
 'use' => 'phpredis-sentinel', // Use Sentinel for Horizon
 
 'environments' => [

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -4,20 +4,20 @@ services:
     network_mode: host
     volumes:
       - ./tests/tls:/tls:ro
+    # The sh wrapper keeps redis-server running as root: the image entrypoint drops
+    # privileges to the redis user for direct redis-server invocations, which cannot
+    # read the mode-600 private key owned by the host user on a Linux CI runner.
     command:
-      - redis-server
-      - --port
-      - "0"
-      - --tls-port
-      - "6393"
-      - --tls-cert-file
-      - /tls/server.crt
-      - --tls-key-file
-      - /tls/server.key
-      - --tls-ca-cert-file
-      - /tls/ca.crt
-      - --tls-auth-clients
-      - "no"
+      - sh
+      - -c
+      - >-
+        exec redis-server
+        --port 0
+        --tls-port 6393
+        --tls-cert-file /tls/server.crt
+        --tls-key-file /tls/server.key
+        --tls-ca-cert-file /tls/ca.crt
+        --tls-auth-clients no
 
   tls-sentinel:
     image: redis:6.2-alpine

--- a/src/Commands/HorizonWorkerPreStop.php
+++ b/src/Commands/HorizonWorkerPreStop.php
@@ -76,10 +76,18 @@ class HorizonWorkerPreStop extends Command
 
             $process->run();
             $output = trim($process->getOutput());
-            $pids = array_filter(explode("\n", $output), fn ($line) => ctype_digit(trim($line)));
 
-            if (! empty($pids)) {
-                $pid = (int) trim($pids[0]);
+            // pgrep -f matches the pre-stop's own command line (it contains the
+            // start command); killing our own PID would abort the hook exactly
+            // when Horizon is already gone — the only case that runs this branch
+            $ownPid = (int) (getmypid() ?: 0);
+            $pids = array_values(array_filter(
+                array_map('trim', explode("\n", $output)),
+                fn (string $line): bool => ctype_digit($line) && (int) $line !== $ownPid
+            ));
+
+            if ($pids !== []) {
+                $pid = (int) $pids[0];
             }
         }
 

--- a/src/Commands/SentinelStatus.php
+++ b/src/Commands/SentinelStatus.php
@@ -68,7 +68,11 @@ class SentinelStatus extends Command
                 $report[$name] = $this->inspect($manager, $name);
             } catch (Throwable $exception) {
                 $failures++;
-                $this->error(sprintf('%s: %s', $name, $exception->getMessage()));
+                $report[$name] = ['error' => $exception->getMessage()];
+
+                if (! $this->option('json')) {
+                    $this->error(sprintf('%s: %s', $name, $exception->getMessage()));
+                }
             }
         }
 
@@ -160,6 +164,11 @@ class SentinelStatus extends Command
     private function renderTables(array $report): void
     {
         foreach ($report as $name => $entry) {
+            // Failures are reported inline by handle() before the tables render
+            if (isset($entry['error'])) {
+                continue;
+            }
+
             $master = $entry['master'];
 
             $this->info(sprintf('%s · service "%s"', $name, $entry['service'] ?? '?'));
@@ -207,18 +216,38 @@ class SentinelStatus extends Command
      */
     private function watch(array $config): int
     {
-        $sentinelConfig = (array) ($config['sentinel'] ?? []);
-        $host = (string) ($sentinelConfig['host'] ?? '');
-        $port = (int) ($sentinelConfig['port'] ?? 26379);
-
-        if ($host === '') {
-            $this->error('No sentinel host configured.');
+        if (isset($config['sentinel']['ssl'])) {
+            $this->error('--watch does not support TLS sentinels.');
 
             return 1;
         }
 
-        if (isset($sentinelConfig['ssl'])) {
-            $this->error('--watch does not support TLS sentinels.');
+        // Same shape resolution the connector uses, so --watch accepts every
+        // documented sentinels form (list, sentinel.sentinels, single host)
+        try {
+            $candidates = RedisSentinelConnector::getSentinels($config);
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return 1;
+        }
+
+        $host = '';
+        $port = 26379;
+
+        foreach ($candidates as $candidate) {
+            $candidateHost = trim((string) ($candidate['host'] ?? ''));
+
+            if ($candidateHost !== '') {
+                $host = $candidateHost;
+                $port = (int) ($candidate['port'] ?? 26379);
+
+                break;
+            }
+        }
+
+        if ($host === '') {
+            $this->error('No sentinel host configured.');
 
             return 1;
         }
@@ -242,7 +271,7 @@ class SentinelStatus extends Command
         // @codeCoverageIgnoreStart
         // Blocking pub/sub: manually smoke-tested against a live Sentinel; not
         // exercisable in-suite because subscribe() never returns until disconnect.
-        $password = (string) ($sentinelConfig['password'] ?? $config['password'] ?? '');
+        $password = (string) ($config['sentinel']['password'] ?? $config['password'] ?? '');
 
         if ($password !== '') {
             $redis->auth($password);

--- a/src/Concerns/Loggable.php
+++ b/src/Concerns/Loggable.php
@@ -18,9 +18,9 @@ trait Loggable
     /**
      * Log a message with context.
      *
-     * If 'phpredis-sentinel.log.channel' is null, Log::channel(null) returns
-     * the default logging channel. This is intentional and allows falling back
-     * to the application's default log channel when no specific channel is configured.
+     * If 'phpredis-sentinel.log.channel' is null, the PSR-3 logger behind the
+     * Log facade is used directly (Log::getLogger()); unlike Log::channel(null)
+     * it bypasses the LogManager channel stack and MessageLogged events.
      *
      * @param  array<string, mixed>  $context
      */

--- a/src/Connections/RedisSentinelConnection.php
+++ b/src/Connections/RedisSentinelConnection.php
@@ -660,11 +660,11 @@ class RedisSentinelConnection extends PhpRedisConnection
     }
 
     /**
-     * phpredis >= 6 reports EVAL/EVALSHA server errors only through
+     * phpredis >= 6 reports script-invocation server errors only through
      * Redis::getLastError(), returning false instead of throwing.
      */
     private function isScriptCommand(string $method): bool
     {
-        return in_array(strtolower($method), ['eval', 'evalsha'], true);
+        return in_array(strtolower($method), ['eval', 'evalsha', 'fcall', 'fcall_ro'], true);
     }
 }

--- a/src/Connectors/NodeAddressCache.php
+++ b/src/Connectors/NodeAddressCache.php
@@ -18,6 +18,24 @@ final class NodeAddressCache
     public function __construct(protected float $ttlSeconds = 0.0, protected ?Closure $clock = null) {}
 
     /**
+     * Resolve the node_cache.ttl config value: any numeric value >= 0 wins (0 is
+     * the documented, discouraged expiry opt-out), while null (Laravel 10+
+     * offsetUnset sets null instead of removing the key), empty strings, garbage
+     * and negatives fall back to the 15 s default — a silent cast to 0.0 would
+     * otherwise disable expiry in long-lived workers and mask failovers.
+     */
+    public static function ttlFromConfig(mixed $value): float
+    {
+        if (is_numeric($value)) {
+            $ttl = (float) $value;
+
+            return $ttl >= 0 ? $ttl : 15.0;
+        }
+
+        return 15.0;
+    }
+
+    /**
      * Get the cached master address for a service.
      *
      * @return array{ip: string, port: int}|null

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -262,6 +262,24 @@ class RedisSentinelConnector extends PhpRedisConnector
     }
 
     /**
+     * Sentinel only ever reports master-link-status ok|err: an errored link means the
+     * replica is disconnected from its master (typical right after a failover or while
+     * links re-establish) and would serve stale reads. Public static so the chaos
+     * suite's convergence barrier waits for exactly the replicas this connector accepts.
+     *
+     * @param  array<string, mixed>  $replica
+     */
+    public static function isHealthyReplica(array $replica): bool
+    {
+        $flags = $replica['flags'] ?? $replica['role-reported'] ?? '';
+
+        return ! str_contains($flags, 's_down')
+            && ! str_contains($flags, 'o_down')
+            && ! str_contains($flags, 'disconnected')
+            && ($replica['master-link-status'] ?? 'ok') === 'ok';
+    }
+
+    /**
      * Get a replica address from Sentinel.
      *
      * @param  array<string, mixed>  $config
@@ -310,17 +328,7 @@ class RedisSentinelConnector extends PhpRedisConnector
             );
 
             // Filter healthy replicas
-            $replicas = array_values(array_filter($slaves, static function ($s) {
-                $flags = $s['flags'] ?? $s['role-reported'] ?? '';
-
-                // Sentinel only ever reports master-link-status ok|err: an errored link
-                // means the replica is disconnected from its master (typical right after
-                // a failover) and would serve stale reads
-                return ! str_contains($flags, 's_down') &&
-                       ! str_contains($flags, 'o_down') &&
-                       ! str_contains($flags, 'disconnected') &&
-                       ($s['master-link-status'] ?? 'ok') === 'ok';
-            }));
+            $replicas = array_values(array_filter($slaves, self::isHealthyReplica(...)));
 
             if (empty($replicas)) {
                 $this->log('No healthy replica, reads fall back to the master', ['service' => $service, 'replicas' => $slaves], 'warning');

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -559,14 +559,31 @@ class RedisSentinelConnector extends PhpRedisConnector
     }
 
     /**
+     * Resolve the configured Sentinel endpoints across all documented config
+     * shapes (sentinels list, sentinel.sentinels, single sentinel host).
+     * Public static so diagnostic readers (sentinel:status --watch) cannot
+     * drift from the shapes the connector accepts.
+     *
      * @param  array<string, mixed>  $config
      * @return array<int, array<string, int|string>>
      */
-    protected function getSentinels(array $config): array
+    public static function getSentinels(array $config): array
     {
         $sentinels = $config['sentinels'] ?? $config['sentinel']['sentinels'] ?? null;
 
         if ($sentinels) {
+            if (! is_array($sentinels)) {
+                throw new ConfigurationException('The sentinels option must be an array of host/port pairs.');
+            }
+
+            foreach ($sentinels as $sentinel) {
+                if (! is_array($sentinel)) {
+                    throw new ConfigurationException(
+                        'Each configured sentinel must be a host/port pair, '.get_debug_type($sentinel).' given.'
+                    );
+                }
+            }
+
             return $sentinels;
         }
 
@@ -711,6 +728,12 @@ class RedisSentinelConnector extends PhpRedisConnector
 
         if ($host === '') {
             return null;
+        }
+
+        // Docker container and service names legally contain underscores, which
+        // FILTER_FLAG_HOSTNAME rejects; accept them as a relaxed hostname form
+        if (str_contains($host, '_')) {
+            return preg_match('/^[A-Za-z0-9_][A-Za-z0-9._-]*[A-Za-z0-9_]$/', $host) === 1 ? $host : null;
         }
 
         if (filter_var($host, FILTER_VALIDATE_IP) !== false

--- a/src/Connectors/RedisSentinelConnector.php
+++ b/src/Connectors/RedisSentinelConnector.php
@@ -313,10 +313,13 @@ class RedisSentinelConnector extends PhpRedisConnector
             $replicas = array_values(array_filter($slaves, static function ($s) {
                 $flags = $s['flags'] ?? $s['role-reported'] ?? '';
 
+                // Sentinel only ever reports master-link-status ok|err: an errored link
+                // means the replica is disconnected from its master (typical right after
+                // a failover) and would serve stale reads
                 return ! str_contains($flags, 's_down') &&
                        ! str_contains($flags, 'o_down') &&
                        ! str_contains($flags, 'disconnected') &&
-                       ($s['master-link-status'] ?? 'ok') !== 'disconnect';
+                       ($s['master-link-status'] ?? 'ok') === 'ok';
             }));
 
             if (empty($replicas)) {

--- a/src/Context/ExecutionContext.php
+++ b/src/Context/ExecutionContext.php
@@ -12,9 +12,17 @@ final class ExecutionContext implements ConnectionContext
     /** @var \ArrayObject<string, mixed> */
     private \ArrayObject $fallback;
 
+    /**
+     * Random per-instance key: spl_object_id() values are reused after GC, which
+     * would let a fresh connection inherit a dead one's ConnectionState (clients,
+     * stickiness) from the shared coroutine context.
+     */
+    private string $token;
+
     public function __construct()
     {
         $this->fallback = new \ArrayObject;
+        $this->token = bin2hex(random_bytes(8));
     }
 
     public static function inCoroutine(): bool
@@ -53,7 +61,7 @@ final class ExecutionContext implements ConnectionContext
 
         if ($context instanceof \ArrayObject) {
             // Keyed per connection: two connections may share one coroutine.
-            return $context['lrs-'.spl_object_id($this)] ??= new \ArrayObject;
+            return $context['lrs-'.$this->token] ??= new \ArrayObject;
         }
 
         // Silent fallback here would make every coroutine share the worker's

--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -31,17 +31,13 @@ class RedisSentinelManager extends RedisManager
         $name = $name ?: 'default';
 
         $normalizedName = $this->patchHorizonConnectionName($name);
+
+        $this->assertConnectionConfigured($name, $normalizedName);
+
         $clientDriver = $this->config[$normalizedName]['client'] ?? $this->driver;
 
         if ($clientDriver !== 'phpredis-sentinel') {
-            $previousDriver = $this->driver;
-            $this->driver = $clientDriver;
-
-            try {
-                return parent::resolve($normalizedName);
-            } finally {
-                $this->driver = $previousDriver;
-            }
+            return $this->resolveNonSentinel($normalizedName, $clientDriver);
         }
 
         $config = $this->parseConnectionConfiguration($this->config[$normalizedName]);
@@ -84,13 +80,61 @@ class RedisSentinelManager extends RedisManager
             return $this->sentinelConnector();
         }
 
-        $previousDriver = $this->driver;
-        $this->driver = $this->config[$normalizedName]['client'] ?? $this->driver;
+        return $this->connectorFor($this->config[$normalizedName]['client'] ?? $this->driver);
+    }
 
-        try {
-            return $this->connector();
-        } finally {
-            $this->driver = $previousDriver;
+    /**
+     * Resolve a plain (non-Sentinel) connection with an explicit driver, so
+     * concurrent resolutions never observe a swapped shared $driver property
+     * (same coroutine race the sentinel path avoids via sentinelConnector()).
+     */
+    private function resolveNonSentinel(string $normalizedName, string $clientDriver): mixed
+    {
+        if (isset($this->config['clusters'][$normalizedName])) {
+            return $this->connectorFor($clientDriver)->connectToCluster(
+                array_map(fn ($config) => $this->parseConnectionConfiguration($config), $this->config['clusters'][$normalizedName]),
+                $this->config['clusters']['options'] ?? [],
+                $this->config['options'] ?? []
+            );
+        }
+
+        $options = $this->config['options'] ?? [];
+
+        return $this->connectorFor($clientDriver)->connect(
+            $this->parseConnectionConfiguration($this->config[$normalizedName]),
+            array_merge(Arr::except($options, 'parameters'), ['parameters' => Arr::get($options, 'parameters.'.$normalizedName, Arr::get($options, 'parameters', []))])
+        );
+    }
+
+    /**
+     * Build the connector for an explicit driver without consulting or mutating
+     * the shared $driver property.
+     */
+    private function connectorFor(string $driver): ?object
+    {
+        $customCreator = $this->customCreators[$driver] ?? null;
+
+        if ($customCreator !== null) {
+            return $customCreator();
+        }
+
+        return match ($driver) {
+            'predis' => new PredisConnector,
+            'phpredis' => new PhpRedisConnector,
+            default => null,
+        };
+    }
+
+    /**
+     * A typo'd connection name must fail with a configuration error, not with the
+     * URL parser's cryptic "Redis host must be a non-empty string" downstream.
+     */
+    private function assertConnectionConfigured(string $name, string $normalizedName): void
+    {
+        if (! isset($this->config[$normalizedName]) && ! isset($this->config['clusters'][$normalizedName])) {
+            throw new ConfigurationException(
+                sprintf('No connection defined with base name %s or overwritten name %s in `database.redis` config', $name, $normalizedName)
+            );
         }
     }
 

--- a/src/RedisSentinelManager.php
+++ b/src/RedisSentinelManager.php
@@ -110,7 +110,7 @@ class RedisSentinelManager extends RedisManager
      * Build the connector for an explicit driver without consulting or mutating
      * the shared $driver property.
      */
-    private function connectorFor(string $driver): ?object
+    private function connectorFor(string $driver): object
     {
         $customCreator = $this->customCreators[$driver] ?? null;
 
@@ -121,7 +121,9 @@ class RedisSentinelManager extends RedisManager
         return match ($driver) {
             'predis' => new PredisConnector,
             'phpredis' => new PhpRedisConnector,
-            default => null,
+            default => throw new ConfigurationException(
+                sprintf('Redis client [%s] is not supported.', $driver)
+            ),
         };
     }
 

--- a/src/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinelServiceProvider.php
@@ -108,8 +108,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton(NodeAddressCache::class, fn ($app) => new NodeAddressCache(
-            // Null counts as missing (Laravel 10+ offsetUnset sets null instead of removing the key).
-            (float) ($app['config']->get('phpredis-sentinel.node_cache.ttl') ?? 15)
+            NodeAddressCache::ttlFromConfig($app['config']->get('phpredis-sentinel.node_cache.ttl'))
         ));
         $this->app->bind('redis.sentinel', RedisSentinelConnector::class);
     }

--- a/tests/Feature/Commands/SentinelStatusTest.php
+++ b/tests/Feature/Commands/SentinelStatusTest.php
@@ -198,3 +198,21 @@ test('formatEvent renders switch-master events with a promotion arrow', function
     expect($line)->toBe('[+switch-master] master 127.0.0.1:6380 -> 127.0.0.1:6381')
         ->and($other)->toBe('[+sdown] master master 127.0.0.1 6380');
 });
+
+test('sentinel:status --watch rejects a malformed sentinels option', function () {
+    config([
+        'database.redis.phpredis-sentinel' => [
+            'client' => 'phpredis-sentinel',
+            'sentinels' => 'not-an-array',
+        ],
+    ]);
+
+    $status = Artisan::call('sentinel:status', [
+        '--connection' => ['phpredis-sentinel'],
+        '--watch' => true,
+    ]);
+    $output = Artisan::output();
+
+    expect($status)->toBe(1)
+        ->and($output)->toContain('The sentinels option must be an array of host/port pairs.');
+});

--- a/tests/Feature/ReadWriteSplittingTest.php
+++ b/tests/Feature/ReadWriteSplittingTest.php
@@ -403,13 +403,14 @@ test('it filters out unhealthy replicas', function () {
     expect($connection->getReadClient()->getHost())->toBe(HOST_3);
 });
 
-test('it filters out replicas with a disconnected master link', function () {
+test('it filters out replicas with an errored master link', function () {
     $sentinelMock = Mockery::mock(RedisSentinel::class);
     $sentinelMock->shouldReceive('ping')->andReturn(true);
     $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
 
+    // Sentinel only ever reports master-link-status ok|err
     $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
-        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'err'],
         ['ip' => HOST_3, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'ok'],
     ]);
 
@@ -446,14 +447,14 @@ test('it filters out replicas with a disconnected master link', function () {
     expect($connection->getReadClient()->getHost())->toBe(HOST_3);
 });
 
-test('it falls back to master when all replicas have a disconnected master link', function () {
+test('it falls back to master when all replicas have an errored master link', function () {
     $sentinelMock = Mockery::mock(RedisSentinel::class);
     $sentinelMock->shouldReceive('ping')->andReturn(true);
     $sentinelMock->shouldReceive('master')->with('mymaster')->andReturn(['ip' => HOST_1, 'port' => 6379]);
 
     $sentinelMock->shouldReceive('slaves')->with('mymaster')->andReturn([
-        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
-        ['ip' => HOST_3, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'disconnect'],
+        ['ip' => HOST_2, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'err'],
+        ['ip' => HOST_3, 'port' => 6379, 'flags' => 'slave', 'master-link-status' => 'err'],
     ]);
 
     $connector = new class($sentinelMock) extends RedisSentinelConnector

--- a/tests/Feature/Toxiproxy/FdLeakTest.php
+++ b/tests/Feature/Toxiproxy/FdLeakTest.php
@@ -42,10 +42,10 @@ test('repeated sentinel failovers do not leak file descriptors on a shared conne
     $monotonicGrowth = array_filter($deltas, fn (int $delta): bool => $delta >= 1) === $deltas;
 
     if ($monotonicGrowth) {
-        $this->markTestSkipped(sprintf(
-            'Descriptor leak across sentinel failovers confirmed: fd counts [%s], per-cycle deltas [%s], total growth %d over 3 cycles (~%.1f fds/cycle).'
+        $this->fail(sprintf(
+            'Descriptor leak across sentinel failovers: fd counts [%s], per-cycle deltas [%s], total growth %d over 3 cycles (~%.1f fds/cycle).'
             .' Each retry-triggered client refresh replaces the master/replica client without closing the old one.'
-            .' Fix candidate: close replaced clients in RedisSentinelConnection::retry() onFail - behavior change deserving its own PR.',
+            .' Fix candidate: close replaced clients in RedisSentinelConnection::retry() onFail.',
             implode(', ', $counts),
             implode(', ', $deltas),
             $total,

--- a/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
+++ b/tests/Support/Toxiproxy/InteractsWithToxiproxy.php
@@ -3,6 +3,7 @@
 namespace Goopil\LaravelRedisSentinel\Tests\Support\Toxiproxy;
 
 use Goopil\LaravelRedisSentinel\Connectors\NodeAddressCache;
+use Goopil\LaravelRedisSentinel\Connectors\RedisSentinelConnector;
 use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Illuminate\Redis\Connections\Connection;
 use Redis;
@@ -322,12 +323,13 @@ trait InteractsWithToxiproxy
     }
 
     /**
-     * Blocks until Sentinel reports two slaves without s_down/o_down/disconnected
-     * flags, because a read-split connection created while the links severed by the
-     * beforeEach proxy reset are still re-establishing would read from the master
+     * Blocks until Sentinel reports two replicas passing the connector's own health
+     * predicate (flags plus master-link-status), because a read-split connection
+     * created while the links severed by the beforeEach proxy reset are still
+     * re-establishing would read from the master
      * (RedisSentinelConnector falls back to the master when no healthy replica exists).
      */
-    public function waitForHealthyReplicas(int $timeoutSeconds = 20): void
+    public function waitForHealthyReplicas(int $timeoutSeconds = 60): void
     {
         $service = (string) config('database.redis.phpredis-sentinel.sentinel.service', 'master');
         $deadline = microtime(true) + $timeoutSeconds;
@@ -341,10 +343,7 @@ trait InteractsWithToxiproxy
                     'connectTimeout' => 0.2,
                 ]);
 
-                $healthy = array_filter((array) $sentinel->slaves($service), static fn ($slave): bool => ! str_contains(
-                    (string) ($slave['flags'] ?? ''),
-                    'disconnected'
-                ) && ! str_contains((string) ($slave['flags'] ?? ''), 's_down'));
+                $healthy = array_filter((array) $sentinel->slaves($service), RedisSentinelConnector::isHealthyReplica(...));
 
                 if (count($healthy) >= 2) {
                     return;

--- a/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
+++ b/tests/Unit/Connections/RedisSentinelConnectionRetryTest.php
@@ -250,6 +250,33 @@ test('a phpredis 6 silent eval error surfaces through getLastError and is retrie
         ->and($refreshes)->toBe(1);
 });
 
+test('a phpredis 6 silent fcall error is retried like eval', function () {
+    Event::fake();
+
+    $demotedMaster = new ScriptFakeRedis;
+    $demotedMaster->nextError = "ERR Error running function: -READONLY You can't write against a read only replica.";
+
+    $promotedMaster = new ScriptFakeRedis;
+
+    $refreshes = 0;
+    $connection = new RedisSentinelConnection(
+        $demotedMaster,
+        function () use (&$refreshes, $promotedMaster) {
+            $refreshes++;
+
+            return $promotedMaster;
+        },
+        [],
+    );
+    $connection->setRetryLimit(2);
+    $connection->setRetryDelay(1);
+    $connection->setRetryMessages(["can't write against a read only replica"]);
+
+    // fcall routes through __call: the command name must land in the script-command list
+    expect($connection->fcall('mywrite', ['queues:default'], ['payload']))->toBeFalse()
+        ->and($refreshes)->toBe(1);
+});
+
 test('an eval returning false without a stored error is returned as-is with no retry', function () {
     Event::fake();
 

--- a/tests/Unit/Connectors/NormalizeHostTest.php
+++ b/tests/Unit/Connectors/NormalizeHostTest.php
@@ -73,3 +73,18 @@ test('normalizeHost rejects invalid formats', function () {
     expect($connector->testNormalizeHost('-invalid-host'))->toBeNull()
         ->and($connector->testNormalizeHost('host with spaces'))->toBeNull();
 });
+
+test('normalizeHost accepts underscore hostnames (Docker service names)', function () {
+    $connector = normalizeHostConnector();
+
+    expect($connector->testNormalizeHost('redis_main'))->toBe('redis_main')
+        ->and($connector->testNormalizeHost('my_service.staging.internal'))->toBe('my_service.staging.internal')
+        ->and($connector->testNormalizeHost('node_1'))->toBe('node_1');
+});
+
+test('normalizeHost rejects malformed underscore hostnames', function () {
+    $connector = normalizeHostConnector();
+
+    expect($connector->testNormalizeHost('bad_host!'))->toBeNull()
+        ->and($connector->testNormalizeHost('host name_x'))->toBeNull();
+});

--- a/tests/Unit/Connectors/RedisSentinelConnectorTest.php
+++ b/tests/Unit/Connectors/RedisSentinelConnectorTest.php
@@ -394,3 +394,16 @@ test('Sentinel readTimeout is pinned to its own sentinel.read_timeout and ignore
 
     expect($connector->capturedOptions['readTimeout'])->toBe(2);
 });
+
+test('getSentinels rejects a non-array sentinels option', function () {
+    RedisSentinelConnector::getSentinels(['sentinels' => '127.0.0.1:26379']);
+})->throws(ConfigurationException::class, 'The sentinels option must be an array of host/port pairs.');
+
+test('getSentinels rejects sentinels entries that are not host/port pairs', function () {
+    RedisSentinelConnector::getSentinels([
+        'sentinels' => [
+            ['host' => '127.0.0.1', 'port' => 26379],
+            'oops',
+        ],
+    ]);
+})->throws(ConfigurationException::class, 'Each configured sentinel must be a host/port pair, string given.');

--- a/tests/Unit/RedisSentinelManagerTest.php
+++ b/tests/Unit/RedisSentinelManagerTest.php
@@ -6,6 +6,8 @@ use Goopil\LaravelRedisSentinel\Exceptions\ConfigurationException;
 use Goopil\LaravelRedisSentinel\RedisSentinelManager;
 use Illuminate\Contracts\Redis\Connector;
 use Illuminate\Redis\Connections\Connection;
+use Illuminate\Redis\Connectors\PhpRedisConnector;
+use Illuminate\Redis\Connectors\PredisConnector;
 use Illuminate\Redis\RedisManager;
 use Laravel\Horizon\Connectors\RedisConnector;
 
@@ -173,6 +175,86 @@ test('sentinel resolution never exposes a swapped driver to the registered creat
         ->and($manager->resolve('default'))->toBe($connection)
         ->and($observed)->each->toBe('phpredis');
 });
+
+test('resolveConnector returns the driver connector for non-sentinel connections', function () {
+    $config = [
+        'other' => [
+            'client' => 'phpredis',
+            'host' => '127.0.0.1',
+        ],
+    ];
+
+    $manager = new RedisSentinelManager(app(), 'phpredis', $config);
+
+    expect($manager->resolveConnector('other'))->toBeInstanceOf(PhpRedisConnector::class);
+});
+
+test('resolveConnector returns the driver connector for predis connections', function () {
+    $manager = new RedisSentinelManager(app(), 'phpredis', [
+        'store' => ['client' => 'predis', 'host' => '127.0.0.1'],
+    ]);
+
+    expect($manager->resolveConnector('store'))->toBeInstanceOf(PredisConnector::class);
+});
+
+test('resolve resolves a non-sentinel cluster through the explicit driver', function () {
+    $config = [
+        'clusters' => [
+            'mycluster' => [
+                ['host' => '127.0.0.1', 'port' => 6379],
+                ['host' => '127.0.0.2', 'port' => 6379],
+            ],
+            'options' => [
+                'cluster' => 'redis',
+            ],
+        ],
+    ];
+
+    $manager = new RedisSentinelManager(app(), 'phpredis', $config);
+
+    $receivedClusterConfig = new ArrayObject;
+    $connection = new class extends Connection
+    {
+        public function createSubscription($channels, Closure $callback, $method = 'subscribe') {}
+    };
+    $connector = new class($connection, $receivedClusterConfig) implements Connector
+    {
+        public function __construct(private readonly Connection $connection, private readonly ArrayObject $receivedClusterConfig) {}
+
+        public function connect(array $config, array $options)
+        {
+            return $this->connection;
+        }
+
+        public function connectToCluster(array $config, array $clusterOptions, array $options)
+        {
+            $this->receivedClusterConfig->exchangeArray($config);
+
+            return $this->connection;
+        }
+    };
+
+    $manager->extend('phpredis', fn () => $connector);
+
+    expect($manager->resolve('mycluster'))->toBe($connection)
+        ->and($receivedClusterConfig)->toHaveCount(2);
+});
+
+test('resolve throws ConfigurationException for an unconfigured connection name', function () {
+    $manager = new RedisSentinelManager(app(), 'phpredis', [
+        'default' => ['host' => '127.0.0.1'],
+    ]);
+
+    $manager->resolve('typo-name');
+})->throws(ConfigurationException::class, 'No connection defined with base name typo-name or overwritten name typo-name in `database.redis` config');
+
+test('resolve fails with a configuration error for an unsupported client driver', function () {
+    $manager = new RedisSentinelManager(app(), 'phpredis', [
+        'other' => ['client' => 'extension-not-installed', 'host' => '127.0.0.1'],
+    ]);
+
+    $manager->resolve('other');
+})->throws(ConfigurationException::class, 'Redis client [extension-not-installed] is not supported.');
 
 if (class_exists(RedisConnector::class)) {
     test('resolve uses normalized name for non-sentinel connections in horizon context', function () {

--- a/tests/Unit/Stubs/ScriptFakeRedis.php
+++ b/tests/Unit/Stubs/ScriptFakeRedis.php
@@ -22,6 +22,15 @@ class ScriptFakeRedis extends \Redis
         return false;
     }
 
+    public function fcall(string $fn, array $keys_or_args = [], ?array $args = null): mixed
+    {
+        if ($this->nextError !== null) {
+            $this->lastError = $this->nextError;
+        }
+
+        return false;
+    }
+
     public function clearLastError(): bool
     {
         $this->lastError = null;


### PR DESCRIPTION
## Summary

Follow-ups from the 2026-09-12 roast, prioritized:

1. **Stale-read fix**: the healthy-replica filter compared `master-link-status !== 'disconnect'`, but Sentinel only ever reports `ok|err` — the check never fired and a replica with an errored master link (typical right after a failover) served stale reads. Now `=== 'ok'` (unknown = unhealthy). Test fixtures used the fabricated `disconnect` value; they now use the real `err`.
2. **Silent script-error retry covers Redis Functions**: phpredis >= 6 swallows `FCALL` errors exactly like `EVAL` (verified: `false` + `getLastError()`, no exception). `fcall`/`fcall_ro` now route through the same discrimination as `eval`/`evalsha`.
3. **Leak guard**: `FdLeakTest` converted a confirmed descriptor-leak signature into a `markTestSkipped` — a detected regression must fail, not skip.
4. **README**: `horizon.driver => 'phpredis-sentinel'` was required by the code but documented nowhere; the documented config shape silently left Horizon on its base connector.

## Test plan

- Unit: fcall silent-error retry test (stub-based, Mockery cannot override `eval` — reserved word).
- Feature: replica filter tests use real Sentinel values; full chaos group + full suite green (618 passed, 3 skipped); lint clean.